### PR TITLE
Implement Dual API Endpoint Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Create a configuration file:
 
 ```json
 {
-  "apiBaseUrl": "http://your-api-server:8080/api",
+  "apiBaseUrl": "http://your-api-server:8080",
   "appTitle": "Your Custom Title",
   "appVersion": "1.0.0",
   "logoUrl": "/your-logo.svg"
@@ -113,7 +113,7 @@ podman run -d -p 8080:8080 \
 
 Configuration options in the JSON file:
 
-- `apiBaseUrl`: Backend API endpoint URL
+- `apiBaseUrl`: Base URL for backend server (serves both `/api/` and `/cloudapi/` endpoints)
 - `appTitle`: Application title
 - `appVersion`: Application version
 - `logoUrl`: Logo image URL
@@ -200,10 +200,27 @@ kubectl edit configmap ssvirt-ui-config
 
 The ConfigMap contains a config.json file with these options:
 
-- `apiBaseUrl`: Backend API endpoint URL (default: "http://ssvirt-backend:8080/api")
+- `apiBaseUrl`: Base URL for backend server (default: "http://ssvirt-backend:8080")
 - `appTitle`: Application title (default: "SSVIRT Web UI")
 - `appVersion`: Application version (default: "1.0.0")
 - `logoUrl`: Logo image URL (default: "/vite.svg")
+
+### API Endpoints
+
+The application communicates with the backend server through two sets of API endpoints:
+
+1. **Legacy API** (`/api/`): Used for traditional operations including:
+   - User profile and preferences management
+   - Organization and VDC queries
+   - Legacy VM power operations
+
+2. **CloudAPI** (`/cloudapi/`): VMware Cloud Director CloudAPI endpoints for:
+   - Authentication and session management
+   - VM creation via vApp instantiation
+   - Modern VM lifecycle operations
+   - Catalog and template browsing
+
+The nginx proxy configuration automatically routes requests to the appropriate backend endpoints based on the URL path.
 
 ### Customization Examples
 

--- a/docs/enhancements/dual-api-endpoint-support.md
+++ b/docs/enhancements/dual-api-endpoint-support.md
@@ -1,0 +1,326 @@
+# Enhancement: Dual API Endpoint Support
+
+## Summary
+
+This enhancement proposal outlines the changes needed to support dual API endpoints in the SSVIRT Web UI application. The API server now serves APIs at two base URLs:
+- `/api/` - Legacy API endpoints
+- `/cloudapi/` - VMware Cloud Director CloudAPI endpoints
+
+This requires updates to the nginx configuration, Kubernetes manifests, API client configuration, and documentation to properly handle both endpoint types.
+
+## Motivation
+
+The application currently uses a single `apiBaseUrl` configuration that points to `/api`, but the implementation now requires access to both `/api/` and `/cloudapi/` endpoints:
+
+- **CloudAPI endpoints** (`/cloudapi/`) are used for:
+  - Authentication and session management
+  - VM creation and management via vApp instantiation
+  - Organization and VDC operations
+  - Catalog and template browsing
+
+- **Legacy API endpoints** (`/api/`) are used for:
+  - User profile and preferences
+  - Organization management
+  - VDC queries
+  - VM power operations
+  - Catalog operations
+
+## Current State Analysis
+
+### Configuration Issues
+1. **Single Base URL**: The current `apiBaseUrl` setting only supports one base path
+2. **Hardcoded Paths**: CloudAPI endpoints are hardcoded with `/cloudapi/` prefix in `API_ENDPOINTS`
+3. **Nginx Configuration**: Only proxies `/api/` requests to the backend
+4. **Incomplete Routing**: No proxy configuration for `/cloudapi/` requests
+
+### Current API Usage Patterns
+- Authentication service uses `/cloudapi/1.0.0/sessions`
+- VM services use both `/cloudapi/` and `/api/` endpoints
+- Most endpoints in `API_ENDPOINTS` still use legacy `/api/` patterns
+- CloudAPI services directly construct full paths with `/cloudapi/` prefix
+
+## Proposed Solution
+
+### 1. Configuration Changes
+
+#### Update `apiBaseUrl` Semantics
+Change the `apiBaseUrl` configuration to represent the **base server URL** rather than a specific API path:
+
+**Before:**
+```json
+{
+  "apiBaseUrl": "/api"
+}
+```
+
+**After:**
+```json
+{
+  "apiBaseUrl": ""
+}
+```
+
+This allows the application to construct both `/api/` and `/cloudapi/` endpoints relative to the base URL.
+
+#### Environment Variables
+Update environment variable documentation to reflect the new semantics:
+- `VITE_API_BASE_URL`: Base URL for all API requests (default: empty string for relative paths)
+
+### 2. API Client Updates
+
+#### Axios Instance Configuration
+Update the API client to handle dual endpoints properly:
+
+```typescript
+// Create separate instances for different API types if needed
+const createApiInstance = (basePath = ''): AxiosInstance => {
+  const config = getConfig();
+  const instance = axios.create({
+    baseURL: `${config.API_BASE_URL}${basePath}`,
+    timeout: 10000,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+  });
+  // ... interceptors
+};
+
+// Main API instance for legacy endpoints
+export const api = createApiInstance('/api');
+
+// CloudAPI instance for VMware Cloud Director endpoints  
+export const cloudApi = createApiInstance('/cloudapi');
+```
+
+#### Service Layer Updates
+Update services to use appropriate API instances:
+
+```typescript
+// Legacy API calls
+const response = await api.get('/v1/organizations');
+
+// CloudAPI calls  
+const response = await cloudApi.get('/1.0.0/sessions');
+```
+
+### 3. Nginx Configuration Updates
+
+Add proxy configuration for CloudAPI endpoints:
+
+```nginx
+# Proxy legacy API requests to backend
+location /api/ {
+    proxy_pass http://api_backend/api/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    
+    # Proxy timeouts and error handling
+    proxy_connect_timeout       5s;
+    proxy_send_timeout          60s;
+    proxy_read_timeout          60s;
+    proxy_next_upstream         error timeout;
+}
+
+# Proxy CloudAPI requests to backend
+location /cloudapi/ {
+    proxy_pass http://api_backend/cloudapi/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    
+    # CloudAPI specific headers
+    proxy_set_header X-VMWARE-VCLOUD-TENANT-CONTEXT $http_x_vmware_vcloud_tenant_context;
+    
+    # Proxy timeouts and error handling
+    proxy_connect_timeout       5s;
+    proxy_send_timeout          60s;
+    proxy_read_timeout          60s;
+    proxy_next_upstream         error timeout;
+}
+```
+
+### 4. Kubernetes Manifest Updates
+
+#### ConfigMap Changes
+Update the configuration to use the new base URL semantics:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssvirt-ui-config
+data:
+  config.json: |
+    {
+      "apiBaseUrl": "",
+      "appTitle": "SSVIRT Web UI",
+      "appVersion": "1.0.0",
+      "logoUrl": "/vite.svg"
+    }
+```
+
+#### Deployment Considerations
+- No changes needed to deployment manifests
+- Service discovery remains the same
+- Health checks continue to work through existing endpoints
+
+### 5. Development Environment
+
+#### Local Development
+Update development proxy configuration in `vite.config.ts`:
+
+```typescript
+export default defineConfig({
+  // ...
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/cloudapi': {
+        target: 'http://localhost:8080', 
+        changeOrigin: true,
+      }
+    }
+  }
+});
+```
+
+## Implementation Plan
+
+### Phase 1: Infrastructure Updates
+1. Update nginx configuration to proxy both `/api/` and `/cloudapi/` endpoints
+2. Update Kubernetes ConfigMap with new `apiBaseUrl` semantics
+3. Update development environment proxy configuration
+
+### Phase 2: API Client Refactoring
+1. Create separate API instances for legacy and CloudAPI endpoints
+2. Update service layer to use appropriate API instances
+3. Refactor endpoint constants to remove hardcoded base paths
+
+### Phase 3: Testing and Validation
+1. Test all existing functionality with new configuration
+2. Verify both API endpoints work correctly
+3. Test authentication flows using CloudAPI
+4. Validate VM creation and management operations
+
+### Phase 4: Documentation
+1. Update deployment documentation
+2. Update development setup instructions
+3. Update API integration documentation
+4. Update troubleshooting guides
+
+## Breaking Changes
+
+### Configuration
+- `apiBaseUrl` semantics change from API-specific path to base URL
+- Existing configurations with `"apiBaseUrl": "/api"` will need to be updated to `"apiBaseUrl": ""`
+
+### Environment Variables
+- `VITE_API_BASE_URL` should be updated in deployment configurations
+- Docker environment files may need updates
+
+## Migration Guide
+
+### For Deployments
+1. Update nginx configuration to include CloudAPI proxy rules
+2. Update ConfigMap `apiBaseUrl` value from `"/api"` to `""`
+3. Restart nginx and frontend pods
+4. Verify both API endpoints are accessible
+
+### For Development
+1. Update local `vite.config.ts` proxy configuration
+2. Update environment variables in `.env` files
+3. Test both legacy and CloudAPI endpoints work correctly
+
+## Testing Strategy
+
+### Unit Tests
+- Test API client configuration with new base URL semantics
+- Test service layer with separate API instances
+- Mock both legacy and CloudAPI responses
+
+### Integration Tests
+- Test authentication flows using CloudAPI endpoints
+- Test VM creation using CloudAPI vApp instantiation
+- Test legacy API operations (user management, etc.)
+- Test error handling for both endpoint types
+
+### End-to-End Tests
+- Test complete user workflows involving both API types
+- Test nginx proxy configuration in deployed environment
+- Test failover and error scenarios
+
+## Security Considerations
+
+### Headers and Authentication
+- Ensure CloudAPI-specific headers are properly forwarded
+- Maintain separation of authentication contexts between API types
+- Validate CORS configuration for both endpoint types
+
+### Access Control
+- Verify nginx access controls apply to both endpoints
+- Ensure rate limiting works for both API types
+- Validate SSL/TLS termination for both paths
+
+## Performance Impact
+
+### Minimal Impact Expected
+- No significant performance degradation anticipated
+- Nginx proxy overhead remains the same
+- API client overhead is minimal with separate instances
+
+### Monitoring
+- Monitor response times for both endpoint types
+- Track error rates separately for legacy vs CloudAPI
+- Monitor nginx proxy metrics for both paths
+
+## Rollback Plan
+
+### Configuration Rollback
+1. Revert nginx configuration to original `/api/` only setup
+2. Revert ConfigMap `apiBaseUrl` to `"/api"`
+3. Restart affected services
+4. CloudAPI functionality will be lost, but legacy features remain
+
+### Code Rollback
+- Code changes are backward compatible
+- Can fallback to single API instance if needed
+- No database or persistent state changes required
+
+## Future Considerations
+
+### API Consolidation
+- Consider migrating all endpoints to CloudAPI standard
+- Plan for eventual deprecation of legacy API endpoints
+- Design abstraction layer for easier future migrations
+
+### Configuration Evolution
+- Consider more sophisticated API endpoint configuration
+- Plan for multi-backend API scenarios
+- Design for microservices API discovery patterns
+
+## Success Criteria
+
+1. **Functional Requirements**
+   - Both `/api/` and `/cloudapi/` endpoints are accessible
+   - Authentication works via CloudAPI endpoints
+   - VM creation works via CloudAPI vApp instantiation
+   - Legacy features continue to work via `/api/` endpoints
+
+2. **Non-Functional Requirements**
+   - No performance degradation
+   - Deployment complexity does not increase significantly
+   - Development environment setup remains straightforward
+   - Monitoring and debugging capabilities are maintained
+
+3. **Operational Requirements**
+   - Nginx configuration is clear and maintainable
+   - Kubernetes manifests are properly documented
+   - Rollback procedures are tested and documented
+   - Migration path is smooth for existing deployments

--- a/docs/enhancements/dual-api-endpoint-support.md
+++ b/docs/enhancements/dual-api-endpoint-support.md
@@ -3,6 +3,7 @@
 ## Summary
 
 This enhancement proposal outlines the changes needed to support dual API endpoints in the SSVIRT Web UI application. The API server now serves APIs at two base URLs:
+
 - `/api/` - Legacy API endpoints
 - `/cloudapi/` - VMware Cloud Director CloudAPI endpoints
 
@@ -28,12 +29,14 @@ The application currently uses a single `apiBaseUrl` configuration that points t
 ## Current State Analysis
 
 ### Configuration Issues
+
 1. **Single Base URL**: The current `apiBaseUrl` setting only supports one base path
 2. **Hardcoded Paths**: CloudAPI endpoints are hardcoded with `/cloudapi/` prefix in `API_ENDPOINTS`
 3. **Nginx Configuration**: Only proxies `/api/` requests to the backend
 4. **Incomplete Routing**: No proxy configuration for `/cloudapi/` requests
 
 ### Current API Usage Patterns
+
 - Authentication service uses `/cloudapi/1.0.0/sessions`
 - VM services use both `/cloudapi/` and `/api/` endpoints
 - Most endpoints in `API_ENDPOINTS` still use legacy `/api/` patterns
@@ -44,9 +47,11 @@ The application currently uses a single `apiBaseUrl` configuration that points t
 ### 1. Configuration Changes
 
 #### Update `apiBaseUrl` Semantics
+
 Change the `apiBaseUrl` configuration to represent the **base server URL** rather than a specific API path:
 
 **Before:**
+
 ```json
 {
   "apiBaseUrl": "/api"
@@ -54,6 +59,7 @@ Change the `apiBaseUrl` configuration to represent the **base server URL** rathe
 ```
 
 **After:**
+
 ```json
 {
   "apiBaseUrl": ""
@@ -63,20 +69,30 @@ Change the `apiBaseUrl` configuration to represent the **base server URL** rathe
 This allows the application to construct both `/api/` and `/cloudapi/` endpoints relative to the base URL.
 
 #### Environment Variables
+
 Update environment variable documentation to reflect the new semantics:
+
 - `VITE_API_BASE_URL`: Base URL for all API requests (default: empty string for relative paths)
 
 ### 2. API Client Updates
 
 #### Axios Instance Configuration
+
 Update the API client to handle dual endpoints properly:
 
 ```typescript
 // Create separate instances for different API types if needed
 const createApiInstance = (basePath = ''): AxiosInstance => {
   const config = getConfig();
+
+  // Normalize baseURL to prevent double slashes
+  const normalizedBaseURL = config.API_BASE_URL.replace(/\/+$/, '');
+  const normalizedBasePath = basePath.startsWith('/')
+    ? basePath
+    : `/${basePath}`;
+
   const instance = axios.create({
-    baseURL: `${config.API_BASE_URL}${basePath}`,
+    baseURL: `${normalizedBaseURL}${normalizedBasePath}`,
     timeout: 10000,
     headers: {
       'Content-Type': 'application/json',
@@ -84,23 +100,26 @@ const createApiInstance = (basePath = ''): AxiosInstance => {
     },
   });
   // ... interceptors
+
+  return instance;
 };
 
 // Main API instance for legacy endpoints
 export const api = createApiInstance('/api');
 
-// CloudAPI instance for VMware Cloud Director endpoints  
+// CloudAPI instance for VMware Cloud Director endpoints
 export const cloudApi = createApiInstance('/cloudapi');
 ```
 
 #### Service Layer Updates
+
 Update services to use appropriate API instances:
 
 ```typescript
 // Legacy API calls
 const response = await api.get('/v1/organizations');
 
-// CloudAPI calls  
+// CloudAPI calls
 const response = await cloudApi.get('/1.0.0/sessions');
 ```
 
@@ -115,8 +134,10 @@ location /api/ {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-    
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
     # Proxy timeouts and error handling
     proxy_connect_timeout       5s;
     proxy_send_timeout          60s;
@@ -130,11 +151,13 @@ location /cloudapi/ {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-    
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
     # CloudAPI specific headers
     proxy_set_header X-VMWARE-VCLOUD-TENANT-CONTEXT $http_x_vmware_vcloud_tenant_context;
-    
+
     # Proxy timeouts and error handling
     proxy_connect_timeout       5s;
     proxy_send_timeout          60s;
@@ -146,6 +169,7 @@ location /cloudapi/ {
 ### 4. Kubernetes Manifest Updates
 
 #### ConfigMap Changes
+
 Update the configuration to use the new base URL semantics:
 
 ```yaml
@@ -164,6 +188,7 @@ data:
 ```
 
 #### Deployment Considerations
+
 - No changes needed to deployment manifests
 - Service discovery remains the same
 - Health checks continue to work through existing endpoints
@@ -171,6 +196,7 @@ data:
 ### 5. Development Environment
 
 #### Local Development
+
 Update development proxy configuration in `vite.config.ts`:
 
 ```typescript
@@ -183,33 +209,37 @@ export default defineConfig({
         changeOrigin: true,
       },
       '/cloudapi': {
-        target: 'http://localhost:8080', 
+        target: 'http://localhost:8080',
         changeOrigin: true,
-      }
-    }
-  }
+      },
+    },
+  },
 });
 ```
 
 ## Implementation Plan
 
 ### Phase 1: Infrastructure Updates
+
 1. Update nginx configuration to proxy both `/api/` and `/cloudapi/` endpoints
 2. Update Kubernetes ConfigMap with new `apiBaseUrl` semantics
 3. Update development environment proxy configuration
 
 ### Phase 2: API Client Refactoring
+
 1. Create separate API instances for legacy and CloudAPI endpoints
 2. Update service layer to use appropriate API instances
 3. Refactor endpoint constants to remove hardcoded base paths
 
 ### Phase 3: Testing and Validation
+
 1. Test all existing functionality with new configuration
 2. Verify both API endpoints work correctly
 3. Test authentication flows using CloudAPI
 4. Validate VM creation and management operations
 
 ### Phase 4: Documentation
+
 1. Update deployment documentation
 2. Update development setup instructions
 3. Update API integration documentation
@@ -218,22 +248,26 @@ export default defineConfig({
 ## Breaking Changes
 
 ### Configuration
+
 - `apiBaseUrl` semantics change from API-specific path to base URL
 - Existing configurations with `"apiBaseUrl": "/api"` will need to be updated to `"apiBaseUrl": ""`
 
 ### Environment Variables
+
 - `VITE_API_BASE_URL` should be updated in deployment configurations
 - Docker environment files may need updates
 
 ## Migration Guide
 
 ### For Deployments
+
 1. Update nginx configuration to include CloudAPI proxy rules
 2. Update ConfigMap `apiBaseUrl` value from `"/api"` to `""`
 3. Restart nginx and frontend pods
 4. Verify both API endpoints are accessible
 
 ### For Development
+
 1. Update local `vite.config.ts` proxy configuration
 2. Update environment variables in `.env` files
 3. Test both legacy and CloudAPI endpoints work correctly
@@ -241,17 +275,20 @@ export default defineConfig({
 ## Testing Strategy
 
 ### Unit Tests
+
 - Test API client configuration with new base URL semantics
 - Test service layer with separate API instances
 - Mock both legacy and CloudAPI responses
 
 ### Integration Tests
+
 - Test authentication flows using CloudAPI endpoints
 - Test VM creation using CloudAPI vApp instantiation
 - Test legacy API operations (user management, etc.)
 - Test error handling for both endpoint types
 
 ### End-to-End Tests
+
 - Test complete user workflows involving both API types
 - Test nginx proxy configuration in deployed environment
 - Test failover and error scenarios
@@ -259,11 +296,13 @@ export default defineConfig({
 ## Security Considerations
 
 ### Headers and Authentication
+
 - Ensure CloudAPI-specific headers are properly forwarded
 - Maintain separation of authentication contexts between API types
 - Validate CORS configuration for both endpoint types
 
 ### Access Control
+
 - Verify nginx access controls apply to both endpoints
 - Ensure rate limiting works for both API types
 - Validate SSL/TLS termination for both paths
@@ -271,11 +310,13 @@ export default defineConfig({
 ## Performance Impact
 
 ### Minimal Impact Expected
+
 - No significant performance degradation anticipated
 - Nginx proxy overhead remains the same
 - API client overhead is minimal with separate instances
 
 ### Monitoring
+
 - Monitor response times for both endpoint types
 - Track error rates separately for legacy vs CloudAPI
 - Monitor nginx proxy metrics for both paths
@@ -283,12 +324,14 @@ export default defineConfig({
 ## Rollback Plan
 
 ### Configuration Rollback
+
 1. Revert nginx configuration to original `/api/` only setup
 2. Revert ConfigMap `apiBaseUrl` to `"/api"`
 3. Restart affected services
 4. CloudAPI functionality will be lost, but legacy features remain
 
 ### Code Rollback
+
 - Code changes are backward compatible
 - Can fallback to single API instance if needed
 - No database or persistent state changes required
@@ -296,11 +339,13 @@ export default defineConfig({
 ## Future Considerations
 
 ### API Consolidation
+
 - Consider migrating all endpoints to CloudAPI standard
 - Plan for eventual deprecation of legacy API endpoints
 - Design abstraction layer for easier future migrations
 
 ### Configuration Evolution
+
 - Consider more sophisticated API endpoint configuration
 - Plan for multi-backend API scenarios
 - Design for microservices API discovery patterns

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   config.json: |
     {
-      "apiBaseUrl": "/api",
+      "apiBaseUrl": "",
       "appTitle": "SSVIRT Web UI",
       "appVersion": "1.0.0",
       "logoUrl": "/vite.svg"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         # Main UI container
         - name: ssvirt-ui
           image: quay.io/mhrivnak/ssvirt-ui:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
               name: ui

--- a/k8s/nginx-configmap.yaml
+++ b/k8s/nginx-configmap.yaml
@@ -35,7 +35,7 @@ data:
         }
         
         upstream api_backend {
-            server ssvirt-backend:8080;
+            server ssvirt-api-server:8080;
         }
         
         server {

--- a/k8s/nginx-configmap.yaml
+++ b/k8s/nginx-configmap.yaml
@@ -65,7 +65,7 @@ data:
                 proxy_next_upstream         error timeout;
             }
             
-            # Proxy API requests to backend
+            # Proxy legacy API requests to backend
             location /api/ {
                 proxy_pass http://api_backend/api/;
                 proxy_set_header Host $host;
@@ -74,6 +74,26 @@ data:
                 proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
                 proxy_set_header Upgrade $http_upgrade;
                 proxy_set_header Connection "upgrade";
+                
+                # Proxy timeouts and error handling
+                proxy_connect_timeout       5s;
+                proxy_send_timeout          60s;
+                proxy_read_timeout          60s;
+                proxy_next_upstream         error timeout;
+            }
+            
+            # Proxy CloudAPI requests to backend
+            location /cloudapi/ {
+                proxy_pass http://api_backend/cloudapi/;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection "upgrade";
+                
+                # CloudAPI specific headers for VMware Cloud Director
+                proxy_set_header X-VMWARE-VCLOUD-TENANT-CONTEXT $http_x_vmware_vcloud_tenant_context;
                 
                 # Proxy timeouts and error handling
                 proxy_connect_timeout       5s;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -30,10 +30,10 @@ function safeBase64Encode(str: string): string {
 }
 
 // Create axios instance with base configuration
-const createApiInstance = (): AxiosInstance => {
+const createApiInstance = (apiPath = '/api'): AxiosInstance => {
   const config = getConfig();
   const instance = axios.create({
-    baseURL: config.API_BASE_URL,
+    baseURL: `${config.API_BASE_URL}${apiPath}`,
     timeout: 10000,
     headers: {
       'Content-Type': 'application/json',
@@ -128,23 +128,37 @@ export function removeTokenType(): void {
   sessionStorage.removeItem(VCD_TOKEN_TYPE_KEY);
 }
 
-// Create the API instance lazily (only when first accessed)
-let apiInstance: AxiosInstance | null = null;
+// Create the API instances lazily (only when first accessed)
+let legacyApiInstance: AxiosInstance | null = null;
+let cloudApiInstance: AxiosInstance | null = null;
 
 /**
- * Reset the API instance to force recreation with updated tokens
+ * Reset the API instances to force recreation with updated tokens
  */
 export function resetApiInstance(): void {
-  apiInstance = null;
+  legacyApiInstance = null;
+  cloudApiInstance = null;
 }
 
+// Legacy API instance for /api/ endpoints
 export const api = new Proxy({} as AxiosInstance, {
   get(_target, prop: keyof AxiosInstance) {
-    if (!apiInstance) {
-      console.log('🚀 Creating API instance (first access)');
-      apiInstance = createApiInstance();
+    if (!legacyApiInstance) {
+      console.log('🚀 Creating legacy API instance (first access)');
+      legacyApiInstance = createApiInstance('/api');
     }
-    return apiInstance[prop];
+    return legacyApiInstance[prop];
+  },
+});
+
+// CloudAPI instance for /cloudapi/ endpoints
+export const cloudApi = new Proxy({} as AxiosInstance, {
+  get(_target, prop: keyof AxiosInstance) {
+    if (!cloudApiInstance) {
+      console.log('🚀 Creating CloudAPI instance (first access)');
+      cloudApiInstance = createApiInstance('/cloudapi');
+    }
+    return cloudApiInstance[prop];
   },
 });
 
@@ -155,10 +169,10 @@ export class AuthService {
    */
   static async login(credentials: LoginRequest): Promise<SessionResponse> {
     try {
-      // Create a temporary instance without interceptors for login
+      // Create a temporary CloudAPI instance without interceptors for login
       const config = getConfig();
       const loginInstance = axios.create({
-        baseURL: config.API_BASE_URL,
+        baseURL: `${config.API_BASE_URL}/cloudapi`,
         timeout: 10000,
         headers: {
           'Content-Type': 'application/json',
@@ -174,7 +188,7 @@ export class AuthService {
       );
 
       const response = await loginInstance.post<SessionResponse>(
-        '/cloudapi/1.0.0/sessions',
+        '/1.0.0/sessions',
         {},
         {
           headers: {
@@ -224,7 +238,7 @@ export class AuthService {
     try {
       const sessionData = getSessionData();
       if (sessionData) {
-        await api.delete(`/cloudapi/1.0.0/sessions/${sessionData.id}`);
+        await cloudApi.delete(`/1.0.0/sessions/${sessionData.id}`);
       }
     } catch (error) {
       // Log error but don't throw - logout should always work locally

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,8 +32,13 @@ function safeBase64Encode(str: string): string {
 // Create axios instance with base configuration
 const createApiInstance = (apiPath = '/api'): AxiosInstance => {
   const config = getConfig();
+
+  // Normalize baseURL to prevent double slashes
+  const normalizedBaseURL = config.API_BASE_URL.replace(/\/+$/, '');
+  const normalizedApiPath = apiPath.startsWith('/') ? apiPath : `/${apiPath}`;
+
   const instance = axios.create({
-    baseURL: `${config.API_BASE_URL}${apiPath}`,
+    baseURL: `${normalizedBaseURL}${normalizedApiPath}`,
     timeout: 10000,
     headers: {
       'Content-Type': 'application/json',

--- a/src/services/cloudapi/VMService.ts
+++ b/src/services/cloudapi/VMService.ts
@@ -19,9 +19,8 @@ export class VMService {
    * Uses CloudAPI to get VDCs with proper organization filtering via JWT
    */
   static async getVDCs(): Promise<VCloudPaginatedResponse<VDC>> {
-    const response = await cloudApi.get<VCloudPaginatedResponse<VDC>>(
-      '/1.0.0/vdcs'
-    );
+    const response =
+      await cloudApi.get<VCloudPaginatedResponse<VDC>>('/1.0.0/vdcs');
     return response.data;
   }
 
@@ -43,9 +42,12 @@ export class VMService {
 
     const url = `/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
 
-    const response = await cloudApi.get<VCloudPaginatedResponse<CatalogItem>>(url, {
-      signal: options?.signal,
-    });
+    const response = await cloudApi.get<VCloudPaginatedResponse<CatalogItem>>(
+      url,
+      {
+        signal: options?.signal,
+      }
+    );
     return response.data;
   }
 
@@ -107,9 +109,8 @@ export class VMService {
    * Used for VM management and overview pages
    */
   static async getVApps(): Promise<VCloudPaginatedResponse<VApp>> {
-    const response = await cloudApi.get<VCloudPaginatedResponse<VApp>>(
-      '/1.0.0/vapps'
-    );
+    const response =
+      await cloudApi.get<VCloudPaginatedResponse<VApp>>('/1.0.0/vapps');
     return response.data;
   }
 
@@ -118,9 +119,8 @@ export class VMService {
    * Provides organization-wide VM visibility
    */
   static async getVMs(): Promise<VCloudPaginatedResponse<VMCloudAPI>> {
-    const response = await cloudApi.get<VCloudPaginatedResponse<VMCloudAPI>>(
-      '/1.0.0/vms'
-    );
+    const response =
+      await cloudApi.get<VCloudPaginatedResponse<VMCloudAPI>>('/1.0.0/vms');
     return response.data;
   }
 
@@ -169,9 +169,7 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async resetVM(vmId: string): Promise<void> {
-    await cloudApi.post(
-      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reset`
-    );
+    await cloudApi.post(`/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reset`);
   }
 
   /**

--- a/src/services/cloudapi/VMService.ts
+++ b/src/services/cloudapi/VMService.ts
@@ -1,4 +1,4 @@
-import { api } from '../api';
+import { cloudApi } from '../api';
 import type {
   VCloudPaginatedResponse,
   VDC,
@@ -19,8 +19,8 @@ export class VMService {
    * Uses CloudAPI to get VDCs with proper organization filtering via JWT
    */
   static async getVDCs(): Promise<VCloudPaginatedResponse<VDC>> {
-    const response = await api.get<VCloudPaginatedResponse<VDC>>(
-      '/cloudapi/1.0.0/vdcs'
+    const response = await cloudApi.get<VCloudPaginatedResponse<VDC>>(
+      '/1.0.0/vdcs'
     );
     return response.data;
   }
@@ -41,9 +41,9 @@ export class VMService {
     if (params?.pageSize)
       queryParams.set('pageSize', params.pageSize.toString());
 
-    const url = `/cloudapi/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
+    const url = `/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems${queryParams.toString() ? `?${queryParams.toString()}` : ''}`;
 
-    const response = await api.get<VCloudPaginatedResponse<CatalogItem>>(url, {
+    const response = await cloudApi.get<VCloudPaginatedResponse<CatalogItem>>(url, {
       signal: options?.signal,
     });
     return response.data;
@@ -59,8 +59,8 @@ export class VMService {
     vdcId: string,
     request: InstantiateTemplateRequest
   ): Promise<VCloudPaginatedResponse<VApp>> {
-    const response = await api.post<VCloudPaginatedResponse<VApp>>(
-      `/cloudapi/1.0.0/vdcs/${encodeURIComponent(vdcId)}/actions/instantiateTemplate`,
+    const response = await cloudApi.post<VCloudPaginatedResponse<VApp>>(
+      `/1.0.0/vdcs/${encodeURIComponent(vdcId)}/actions/instantiateTemplate`,
       request
     );
     return response.data;
@@ -72,8 +72,8 @@ export class VMService {
    * @param vappId The vApp URN
    */
   static async getVApp(vappId: string): Promise<VApp> {
-    const response = await api.get<VApp>(
-      `/cloudapi/1.0.0/vapps/${encodeURIComponent(vappId)}`
+    const response = await cloudApi.get<VApp>(
+      `/1.0.0/vapps/${encodeURIComponent(vappId)}`
     );
     return response.data;
   }
@@ -84,8 +84,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async getVM(vmId: string): Promise<VMCloudAPI> {
-    const response = await api.get<VMCloudAPI>(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}`
+    const response = await cloudApi.get<VMCloudAPI>(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}`
     );
     return response.data;
   }
@@ -96,8 +96,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async getVMHardware(vmId: string): Promise<VMHardwareSection> {
-    const response = await api.get<VMHardwareSection>(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/virtualHardwareSection`
+    const response = await cloudApi.get<VMHardwareSection>(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/virtualHardwareSection`
     );
     return response.data;
   }
@@ -107,8 +107,8 @@ export class VMService {
    * Used for VM management and overview pages
    */
   static async getVApps(): Promise<VCloudPaginatedResponse<VApp>> {
-    const response = await api.get<VCloudPaginatedResponse<VApp>>(
-      '/cloudapi/1.0.0/vapps'
+    const response = await cloudApi.get<VCloudPaginatedResponse<VApp>>(
+      '/1.0.0/vapps'
     );
     return response.data;
   }
@@ -118,8 +118,8 @@ export class VMService {
    * Provides organization-wide VM visibility
    */
   static async getVMs(): Promise<VCloudPaginatedResponse<VMCloudAPI>> {
-    const response = await api.get<VCloudPaginatedResponse<VMCloudAPI>>(
-      '/cloudapi/1.0.0/vms'
+    const response = await cloudApi.get<VCloudPaginatedResponse<VMCloudAPI>>(
+      '/1.0.0/vms'
     );
     return response.data;
   }
@@ -129,8 +129,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async powerOnVM(vmId: string): Promise<void> {
-    await api.post(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/actions/powerOn`
+    await cloudApi.post(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/powerOn`
     );
   }
 
@@ -139,8 +139,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async powerOffVM(vmId: string): Promise<void> {
-    await api.post(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/actions/powerOff`
+    await cloudApi.post(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/powerOff`
     );
   }
 
@@ -149,8 +149,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async rebootVM(vmId: string): Promise<void> {
-    await api.post(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reboot`
+    await cloudApi.post(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reboot`
     );
   }
 
@@ -159,8 +159,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async suspendVM(vmId: string): Promise<void> {
-    await api.post(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/actions/suspend`
+    await cloudApi.post(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/suspend`
     );
   }
 
@@ -169,8 +169,8 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async resetVM(vmId: string): Promise<void> {
-    await api.post(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reset`
+    await cloudApi.post(
+      `/1.0.0/vms/${encodeURIComponent(vmId)}/actions/reset`
     );
   }
 
@@ -179,7 +179,7 @@ export class VMService {
    * @param vappId The vApp URN
    */
   static async deleteVApp(vappId: string): Promise<void> {
-    await api.delete(`/cloudapi/1.0.0/vapps/${encodeURIComponent(vappId)}`);
+    await cloudApi.delete(`/1.0.0/vapps/${encodeURIComponent(vappId)}`);
   }
 
   /**
@@ -187,6 +187,6 @@ export class VMService {
    * @param vmId The VM URN
    */
   static async deleteVM(vmId: string): Promise<void> {
-    await api.delete(`/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}`);
+    await cloudApi.delete(`/1.0.0/vms/${encodeURIComponent(vmId)}`);
   }
 }

--- a/src/services/userProfile.ts
+++ b/src/services/userProfile.ts
@@ -20,7 +20,7 @@ export class UserProfileService {
   static async getUserPreferences(): Promise<UserPreferences> {
     try {
       const response = await api.get<ApiResponse<UserPreferences>>(
-        API_ENDPOINTS.USER_PREFERENCES
+        API_ENDPOINTS.LEGACY.USER_PREFERENCES
       );
 
       if (response.data.success && response.data.data) {
@@ -44,7 +44,7 @@ export class UserProfileService {
   ): Promise<UserPreferences> {
     try {
       const response = await api.put<ApiResponse<UserPreferences>>(
-        API_ENDPOINTS.USER_PREFERENCES,
+        API_ENDPOINTS.LEGACY.USER_PREFERENCES,
         request
       );
 
@@ -67,7 +67,7 @@ export class UserProfileService {
   static async changePassword(request: ChangePasswordRequest): Promise<void> {
     try {
       const response = await api.put<ApiResponse<void>>(
-        API_ENDPOINTS.USER_PASSWORD,
+        API_ENDPOINTS.LEGACY.USER_PASSWORD,
         request
       );
 
@@ -86,7 +86,7 @@ export class UserProfileService {
   static async getSecuritySettings(): Promise<SecuritySetting[]> {
     try {
       const response = await api.get<ApiResponse<SecuritySetting[]>>(
-        API_ENDPOINTS.USER_SECURITY_SETTINGS
+        API_ENDPOINTS.LEGACY.USER_SECURITY_SETTINGS
       );
 
       if (response.data.success && response.data.data) {
@@ -110,7 +110,7 @@ export class UserProfileService {
   ): Promise<SecuritySetting> {
     try {
       const response = await api.put<ApiResponse<SecuritySetting>>(
-        API_ENDPOINTS.USER_SECURITY_SETTING(request.setting_id),
+        API_ENDPOINTS.LEGACY.USER_SECURITY_SETTING(request.setting_id),
         { enabled: request.enabled }
       );
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,7 +3,7 @@ import { getRuntimeConfig } from './config';
 // Fallback configuration for when runtime config is not available (e.g., tests)
 const FALLBACK_CONFIG = {
   API_BASE_URL:
-    import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api',
+    import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
   APP_TITLE: import.meta.env.VITE_APP_TITLE || 'SSVIRT Web UI',
   APP_VERSION: import.meta.env.VITE_APP_VERSION || '0.0.1',
   DEV_MODE: import.meta.env.VITE_DEV_MODE === 'true',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,66 +46,84 @@ export const CONFIG = new Proxy({} as ReturnType<typeof getConfig>, {
   },
 });
 
-// API endpoints
+// API endpoints - organized by API type
 export const API_ENDPOINTS = {
-  // Authentication - CloudAPI compatible
-  LOGIN: '/cloudapi/1.0.0/sessions',
-  LOGOUT: '/cloudapi/1.0.0/sessions',
-  SESSION: '/cloudapi/1.0.0/session',
+  // CloudAPI endpoints (use with cloudApi instance)
+  CLOUDAPI: {
+    // Authentication
+    LOGIN: '/1.0.0/sessions',
+    LOGOUT: '/1.0.0/sessions',
+    SESSION: '/1.0.0/session',
+    
+    // Users
+    USERS: '/1.0.0/users',
+    CURRENT_USER: '/1.0.0/users/current',
+    USER_BY_ID: (id: string) => `/1.0.0/users/${encodeURIComponent(id)}`,
+    
+    // Roles
+    ROLES: '/1.0.0/roles',
+    ROLE_BY_ID: (id: string) => `/1.0.0/roles/${encodeURIComponent(id)}`,
+    
+    // Organizations
+    ORGANIZATIONS: '/1.0.0/orgs',
+    ORGANIZATION_BY_ID: (id: string) => `/1.0.0/orgs/${encodeURIComponent(id)}`,
+    
+    // VDCs
+    VDCS: '/1.0.0/vdcs',
+    VDC_BY_ID: (id: string) => `/1.0.0/vdcs/${encodeURIComponent(id)}`,
+    
+    // VMs and vApps
+    VMS: '/1.0.0/vms',
+    VM_BY_ID: (id: string) => `/1.0.0/vms/${encodeURIComponent(id)}`,
+    VAPPS: '/1.0.0/vapps',
+    VAPP_BY_ID: (id: string) => `/1.0.0/vapps/${encodeURIComponent(id)}`,
+    
+    // Catalogs
+    CATALOGS: '/1.0.0/catalogs',
+    CATALOG_BY_ID: (id: string) => `/1.0.0/catalogs/${encodeURIComponent(id)}`,
+    CATALOG_ITEMS: (catalogId: string) => `/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems`,
+  },
 
-  // CloudAPI Users
-  CLOUDAPI_USERS: '/cloudapi/1.0.0/users',
-  CLOUDAPI_CURRENT_USER: '/cloudapi/1.0.0/users/current',
-  CLOUDAPI_USER_BY_ID: (id: string) =>
-    `/cloudapi/1.0.0/users/${encodeURIComponent(id)}`,
+  // Legacy API endpoints (use with api instance)
+  LEGACY: {
+    // User
+    USER_PROFILE: '/v1/user/profile',
+    USER_PREFERENCES: '/v1/user/preferences',
+    USER_PASSWORD: '/v1/user/password',
+    USER_SECURITY_SETTINGS: '/v1/user/security/settings',
+    USER_SECURITY_SETTING: (settingId: string) =>
+      `/v1/user/security/settings/${settingId}`,
 
-  // CloudAPI Roles
-  CLOUDAPI_ROLES: '/cloudapi/1.0.0/roles',
-  CLOUDAPI_ROLE_BY_ID: (id: string) =>
-    `/cloudapi/1.0.0/roles/${encodeURIComponent(id)}`,
+    // Organizations
+    ORGANIZATIONS: '/org',
+    ORGANIZATION_BY_ID: (id: string) => `/org/${id}`,
 
-  // CloudAPI Organizations
-  CLOUDAPI_ORGANIZATIONS: '/cloudapi/1.0.0/orgs',
-  CLOUDAPI_ORGANIZATION_BY_ID: (id: string) =>
-    `/cloudapi/1.0.0/orgs/${encodeURIComponent(id)}`,
+    // VDCs
+    VDC_BY_ID: (id: string) => `/vdc/${id}`,
+    VDCS_BY_ORG: (orgId: string) => `/org/${orgId}/vdcs/query`,
 
-  // User
-  USER_PROFILE: '/v1/user/profile',
-  USER_PREFERENCES: '/v1/user/preferences',
-  USER_PASSWORD: '/v1/user/password',
-  USER_SECURITY_SETTINGS: '/v1/user/security/settings',
-  USER_SECURITY_SETTING: (settingId: string) =>
-    `/v1/user/security/settings/${settingId}`,
+    // VMs
+    VM_BY_ID: (id: string) => `/vm/${id}`,
+    VMS_BY_VAPP: (vappId: string) => `/vApp/${vappId}/vms/query`,
+    VM_POWER_ACTION: (vmId: string, action: string) =>
+      `/vm/${vmId}/power/action/${action}`,
 
-  // Organizations
-  ORGANIZATIONS: '/org',
-  ORGANIZATION_BY_ID: (id: string) => `/org/${id}`,
+    // vApps
+    INSTANTIATE_VAPP: (vdcId: string) =>
+      `/vdc/${vdcId}/action/instantiateVAppTemplate`,
 
-  // VDCs
-  VDC_BY_ID: (id: string) => `/vdc/${id}`,
-  VDCS_BY_ORG: (orgId: string) => `/org/${orgId}/vdcs/query`,
+    // Catalogs
+    CATALOGS_BY_ORG: (orgId: string) => `/org/${orgId}/catalogs/query`,
+    CATALOG_BY_ID: (id: string) => `/catalog/${id}`,
+    CATALOG_ITEMS: (catalogId: string) =>
+      `/catalog/${catalogId}/catalogItems/query`,
+    CATALOG_ITEM_BY_ID: (id: string) => `/catalogItem/${id}`,
 
-  // VMs
-  VM_BY_ID: (id: string) => `/vm/${id}`,
-  VMS_BY_VAPP: (vappId: string) => `/vApp/${vappId}/vms/query`,
-  VM_POWER_ACTION: (vmId: string, action: string) =>
-    `/vm/${vmId}/power/action/${action}`,
-
-  // vApps
-  INSTANTIATE_VAPP: (vdcId: string) =>
-    `/vdc/${vdcId}/action/instantiateVAppTemplate`,
-
-  // Catalogs
-  CATALOGS_BY_ORG: (orgId: string) => `/org/${orgId}/catalogs/query`,
-  CATALOG_BY_ID: (id: string) => `/catalog/${id}`,
-  CATALOG_ITEMS: (catalogId: string) =>
-    `/catalog/${catalogId}/catalogItems/query`,
-  CATALOG_ITEM_BY_ID: (id: string) => `/catalogItem/${id}`,
-
-  // System
-  HEALTH: '/health',
-  READY: '/ready',
-  VERSION: '/v1/version',
+    // System
+    HEALTH: '/health',
+    READY: '/ready',
+    VERSION: '/v1/version',
+  },
 } as const;
 
 // VM Power Actions

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,8 +2,7 @@ import { getRuntimeConfig } from './config';
 
 // Fallback configuration for when runtime config is not available (e.g., tests)
 const FALLBACK_CONFIG = {
-  API_BASE_URL:
-    import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+  API_BASE_URL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
   APP_TITLE: import.meta.env.VITE_APP_TITLE || 'SSVIRT Web UI',
   APP_VERSION: import.meta.env.VITE_APP_VERSION || '0.0.1',
   DEV_MODE: import.meta.env.VITE_DEV_MODE === 'true',
@@ -54,34 +53,35 @@ export const API_ENDPOINTS = {
     LOGIN: '/1.0.0/sessions',
     LOGOUT: '/1.0.0/sessions',
     SESSION: '/1.0.0/session',
-    
+
     // Users
     USERS: '/1.0.0/users',
     CURRENT_USER: '/1.0.0/users/current',
     USER_BY_ID: (id: string) => `/1.0.0/users/${encodeURIComponent(id)}`,
-    
+
     // Roles
     ROLES: '/1.0.0/roles',
     ROLE_BY_ID: (id: string) => `/1.0.0/roles/${encodeURIComponent(id)}`,
-    
+
     // Organizations
     ORGANIZATIONS: '/1.0.0/orgs',
     ORGANIZATION_BY_ID: (id: string) => `/1.0.0/orgs/${encodeURIComponent(id)}`,
-    
+
     // VDCs
     VDCS: '/1.0.0/vdcs',
     VDC_BY_ID: (id: string) => `/1.0.0/vdcs/${encodeURIComponent(id)}`,
-    
+
     // VMs and vApps
     VMS: '/1.0.0/vms',
     VM_BY_ID: (id: string) => `/1.0.0/vms/${encodeURIComponent(id)}`,
     VAPPS: '/1.0.0/vapps',
     VAPP_BY_ID: (id: string) => `/1.0.0/vapps/${encodeURIComponent(id)}`,
-    
+
     // Catalogs
     CATALOGS: '/1.0.0/catalogs',
     CATALOG_BY_ID: (id: string) => `/1.0.0/catalogs/${encodeURIComponent(id)}`,
-    CATALOG_ITEMS: (catalogId: string) => `/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems`,
+    CATALOG_ITEMS: (catalogId: string) =>
+      `/1.0.0/catalogs/${encodeURIComponent(catalogId)}/catalogItems`,
   },
 
   // Legacy API endpoints (use with api instance)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,18 @@ import react from '@vitejs/plugin-react';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/cloudapi': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      }
+    }
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

This PR implements comprehensive dual API endpoint support for the SSVIRT Web UI, enabling the application to communicate with both legacy (`/api/`) and CloudAPI (`/cloudapi/`) endpoints as documented in the enhancement proposal.

## Changes Made

### 📋 Enhancement Proposal
- Created comprehensive enhancement proposal at `docs/enhancements/dual-api-endpoint-support.md`
- Documented motivation, implementation plan, breaking changes, and migration guide

### 🏗️ Infrastructure Updates
- **Nginx Configuration**: Added CloudAPI proxy route with VMware-specific headers
- **Kubernetes ConfigMap**: Updated `apiBaseUrl` from `/api` to `` (empty string)  
- **Development Environment**: Added proxy configuration for both endpoints in `vite.config.ts`

### 🔧 API Client Refactoring
- **Dual API Instances**: Created separate `api` and `cloudApi` instances with proper base URLs
- **Updated VMService**: All CloudAPI calls now use `cloudApi` with clean URLs (no `/cloudapi` prefix)
- **Authentication**: Login/logout services properly use CloudAPI endpoints
- **Configuration**: Changed `apiBaseUrl` semantics from API-specific path to base server URL

### 📊 API Endpoints Reorganization
- **Structured Constants**: Reorganized `API_ENDPOINTS` into `CLOUDAPI` and `LEGACY` sections
- **Clean Separation**: Removed hardcoded `/cloudapi` prefixes from constants
- **Service Updates**: Updated userProfile service to use new `API_ENDPOINTS.LEGACY` structure

### 📚 Documentation Updates
- **README.md**: Updated configuration examples and added API endpoints explanation
- **Configuration Examples**: Changed from `"/api"` to `""` for proper base URL usage
- **API Documentation**: Explained the difference between legacy and CloudAPI endpoints

## Breaking Changes

⚠️ **Configuration Change**: `apiBaseUrl` now expects base server URL instead of full API path
- **Before**: `"apiBaseUrl": "/api"`
- **After**: `"apiBaseUrl": ""`

## Migration Guide

### For Kubernetes Deployments
1. Update ConfigMap `apiBaseUrl` value from `"/api"` to `""`
2. Apply nginx configuration changes for CloudAPI proxy
3. Restart nginx and frontend pods

### For Development
1. Update local environment variables in `.env` files
2. The new `vite.config.ts` proxy configuration handles both endpoints automatically

## Quality Assurance

✅ **All tests pass**: `npm test`  
✅ **Linting passes**: `npm run lint`  
✅ **Type checking passes**: `npm run typecheck`  
✅ **Build succeeds**: `make build`

## API Endpoints Overview

The application now properly supports:

1. **Legacy API** (`/api/`): User management, organizations, legacy VM operations
2. **CloudAPI** (`/cloudapi/`): Authentication, VM creation via vApp instantiation, modern VM lifecycle operations

## Testing

- [x] Build compilation successful
- [x] All existing tests pass
- [x] Linting and type checking pass
- [x] Nginx proxy configuration tested
- [x] API client instances work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dual API endpoint support via reverse proxy: /api (Legacy) and /cloudapi (CloudAPI) with separate clients and distinct routing for login/logout and VM operations.
- Documentation
  - README, deployment guides, and an enhancement doc updated with new apiBaseUrl semantics, API Endpoints, migration steps, and security/testing guidance.
- Chores
  - NGINX and Dev server proxies added for both endpoints; ConfigMap defaults apiBaseUrl set to "" (base host); k8s deployment sets imagePullPolicy: Always.
- API Surface
  - Public API endpoint constants restructured into CLOUDAPI and LEGACY groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->