### PR TITLE
feat: Implement vApp creation from catalog templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 .issues
 .todo.md
 .todo
+console.log

--- a/docs/enhancements/vapp-creation-from-templates.md
+++ b/docs/enhancements/vapp-creation-from-templates.md
@@ -1,0 +1,373 @@
+# vApp Creation from Catalog Templates Enhancement
+
+## Overview
+
+This document outlines the implementation plan for adding vApp creation
+functionality to catalog template views in the SSVirt UI. Users will be able to
+directly create vApps from catalog templates by clicking a "Create vApp" button,
+filling out a modal form, and submitting the creation request through the
+CloudAPI.
+
+## Current State
+
+### Existing Implementation
+- **Catalog Template Viewing**: Users can browse catalog templates in the Templates tab of catalog detail pages
+- **Template Cards**: Each template is displayed in a card format with basic information (name, description, version, parameters)
+- **CloudAPI Integration**: Complete infrastructure for CloudAPI calls with authentication and error handling
+- **vApp Management**: Basic vApp listing and detail views exist but lack creation capabilities
+- **VDC Integration**: VDC selection and management functionality is available
+
+### Current Limitations
+1. **No vApp Creation UI**: Users cannot create vApps directly from templates through the UI
+2. **Missing Template-to-vApp Workflow**: No direct path from template browsing to vApp instantiation
+3. **Limited Action Options**: Template cards only show "View Details" and "Deploy" placeholder actions
+4. **No VDC Context Integration**: Template views don't integrate with VDC selection for vApp placement
+
+## Target State
+
+### vApp Creation Workflow
+- **Create vApp Button**: Each template card shows a prominent "Create vApp" action button
+- **Modal Form Interface**: Clicking opens a well-designed modal for vApp configuration
+- **VDC Selection**: Users can select target VDC for vApp deployment
+- **Form Validation**: Real-time validation with clear error messages and input requirements
+- **Progress Feedback**: Clear loading states and success/error feedback during creation process
+
+### Integration Points
+- **Template Card Actions**: Enhanced with "Create vApp" primary action alongside existing options
+- **VDC Context**: Integration with user's available VDCs for target selection
+- **Navigation Flow**: Seamless navigation to created vApp details after successful creation
+- **Permission Guards**: Proper role-based access control for vApp creation capabilities
+
+## API Compliance
+
+### CloudAPI Endpoint
+Based on the [SSVirt API Reference](https://raw.githubusercontent.com/mhrivnak/ssvirt/refs/heads/main/docs/api-reference.md):
+
+#### vApp Template Instantiation
+- **Create vApp from Template**: `POST /cloudapi/1.0.0/vdcs/{vdc_id}/actions/instantiateTemplate`
+  - Request Body:
+    ```json
+    {
+      "name": "string",           // Required: Name of the new vApp
+      "description": "string",    // Optional: Description of the vApp
+      "catalogItem": {
+        "id": "string",          // Required: URN of the catalog item/template
+        "name": "string"         // Optional: Name of the catalog item
+      }
+    }
+    ```
+  - Response: `201 Created` with vApp object containing ID, name, status, and metadata
+  - Authentication: Bearer Token via existing CloudAPI auth system
+
+#### Related Endpoints
+- **List VDCs**: `GET /cloudapi/1.0.0/vdcs` (existing) - For VDC selection dropdown
+- **VDC Details**: `GET /cloudapi/1.0.0/vdcs/{vdc_id}` (existing) - For VDC validation
+- **vApp Details**: `GET /cloudapi/1.0.0/vapps/{vapp_id}` (existing) - For post-creation navigation
+
+### Authentication & Authorization
+All operations require Bearer Token authentication via the existing CloudAPI auth system and appropriate role permissions for vApp creation within the target VDC.
+
+## Implementation Plan
+
+### Phase 1: Core vApp Creation Modal (Priority: High)
+
+#### 1.1 Create vApp Creation Form Component
+```typescript
+// src/components/vapps/CreateVAppModal.tsx
+interface CreateVAppModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  catalogItem: CatalogItem;
+  onSuccess?: (vappId: string) => void;
+}
+```
+
+**Features**:
+- Modal-based form with CloudAPI integration
+- Fields: vApp Name (required), Description (optional), Target VDC (required dropdown)
+- VDC selection populated from user's available VDCs
+- Real-time validation with error display
+- Loading states during creation process
+- Success feedback with navigation option
+
+#### 1.2 Enhance Template Card Actions
+```typescript
+// Update src/components/catalogs/CatalogItemCard.tsx
+const cardActions = [
+  {
+    title: 'Create vApp',
+    variant: 'primary',
+    icon: <PlayIcon />,
+    onClick: () => setCreateVAppModal({ isOpen: true, catalogItem }),
+  },
+  {
+    title: 'View Details',
+    variant: 'secondary', 
+    icon: <InfoCircleIcon />,
+    onClick: () => onViewDetails(catalogItem),
+  }
+];
+```
+
+**Integration Points**:
+- Add "Create vApp" as primary action on template cards
+- Trigger creation modal with template context pre-filled
+- Handle modal state management and success callbacks
+- Show appropriate actions based on user permissions
+
+#### 1.3 VDC Selection Integration
+```typescript
+// Enhance useVDCs hook for user-accessible VDCs
+const { data: userVDCs } = useVDCs({
+  filter: 'accessible', // Only VDCs user can deploy to
+  organizationId: currentOrgId,
+});
+```
+
+**Features**:
+- Fetch and display user's accessible VDCs
+- VDC dropdown with search/filter capabilities
+- Validation to ensure selected VDC supports vApp creation
+- Permission-based VDC filtering
+
+### Phase 2: Form Validation & UX (Priority: High)
+
+#### 2.1 Comprehensive Form Validation
+- **vApp Name**: Required, 1-255 characters, unique within VDC validation
+- **Description**: Optional, up to 1024 characters
+- **VDC Selection**: Required, must be accessible to user
+- **Real-time Validation**: Field-level and form-level error display
+- **Async Validation**: Check vApp name uniqueness within selected VDC
+
+#### 2.2 Enhanced User Experience
+- **Loading States**: Disable form during submission, show progress indicators
+- **Error Handling**: Clear error messages for validation and API failures
+- **Success Flow**: Success notification with options to view created vApp or create another
+- **Form Persistence**: Remember form data during session for better UX
+
+#### 2.3 Responsive Design
+- **Mobile Support**: Optimize modal layout for mobile devices
+- **Accessibility**: Proper ARIA labels, keyboard navigation, screen reader support
+- **PatternFly Compliance**: Use PatternFly v6 components and design patterns
+
+### Phase 3: Integration & Navigation (Priority: Medium)
+
+#### 3.1 Enhanced Template Actions
+```typescript
+// Update catalog template views to include vApp creation
+const templateActions = [
+  {
+    title: 'Create vApp',
+    primary: true,
+    permission: 'canCreateVApps',
+    action: (template) => openCreateVAppModal(template),
+  },
+  {
+    title: 'View Template Details', 
+    secondary: true,
+    action: (template) => navigateToTemplateDetails(template),
+  }
+];
+```
+
+#### 3.2 Post-Creation Navigation
+- **Success Redirect**: Navigate to created vApp details page after successful creation
+- **vApp List Integration**: Option to return to vApp list with newly created vApp highlighted
+- **Breadcrumb Updates**: Maintain proper navigation context throughout the flow
+
+
+## Technical Architecture
+
+### Component Structure
+```
+src/
+├── components/vapps/
+│   ├── CreateVAppModal.tsx          # Main vApp creation form modal
+│   ├── VDCSelector.tsx              # VDC selection dropdown component
+│   └── VAppCreationProgress.tsx     # Progress tracking component
+├── hooks/
+│   ├── useCreateVApp.ts             # vApp creation mutation hook
+│   ├── useAccessibleVDCs.ts         # User-accessible VDCs hook
+│   └── useVAppNameValidation.ts     # vApp name uniqueness validation
+└── services/cloudapi/
+    └── VAppService.ts               # Enhanced with creation methods
+```
+
+### State Management
+- **React Query**: Leverage existing infrastructure for vApp creation mutations
+- **Cache Invalidation**: Automatic refresh of vApp lists after creation
+- **Optimistic Updates**: Immediate UI feedback for better UX
+- **Error Boundaries**: Graceful error handling for failed operations
+
+### API Service Layer
+```typescript
+// Enhanced VAppService with creation capabilities
+export class VAppService {
+  static async createFromTemplate(request: CreateVAppFromTemplateRequest): Promise<VApp> {
+    return cloudApi.post(`/vdcs/${request.vdcId}/actions/instantiateTemplate`, {
+      name: request.name,
+      description: request.description,
+      catalogItem: {
+        id: request.catalogItemId,
+        name: request.catalogItemName,
+      }
+    });
+  }
+
+  static async validateVAppName(vdcId: string, name: string): Promise<boolean> {
+    // Check if vApp name is unique within VDC
+  }
+}
+```
+
+### Permission Integration
+```typescript
+// Enhanced permission checks for vApp creation
+const canCreateVApps = userPermissions?.canManageVApps && 
+                       userPermissions?.canAccessVDC?.(selectedVdcId);
+```
+
+## User Experience Design
+
+### vApp Creation Flow
+1. **Template Discovery**: User browses catalog templates in Templates tab
+2. **Action Selection**: User clicks "Create vApp" button on desired template card
+3. **Modal Opening**: vApp creation modal opens with template context pre-filled
+4. **Form Completion**: User fills out vApp name, description, and selects target VDC
+5. **Validation**: Real-time validation provides immediate feedback
+6. **Submission**: User clicks "Create vApp" with loading state and progress indication
+7. **Success Handling**: Success notification with navigation options to view created vApp
+
+### Form Interaction Design
+1. **Template Context**: Template name and details displayed prominently in modal header
+2. **Smart Defaults**: Pre-populate reasonable defaults (e.g., vApp name based on template name)
+3. **Progressive Disclosure**: Show advanced options only when needed
+4. **Validation Feedback**: Clear, actionable error messages with field-level highlighting
+5. **Loading States**: Disable form during submission, show progress spinners
+
+### Error Handling
+1. **Validation Errors**: Inline field errors with clear corrective guidance
+2. **API Errors**: User-friendly error messages with retry options
+3. **Permission Errors**: Clear explanation of missing permissions with guidance
+4. **Network Errors**: Retry mechanisms with offline state handling
+
+## Security Considerations
+
+### Access Control
+- **VDC Permissions**: Users can only create vApps in VDCs they have access to
+- **Template Access**: Respect catalog and template visibility permissions
+- **Organization Scoping**: Ensure vApps are created within user's organization context
+- **Role Validation**: Validate user roles support vApp creation operations
+
+### Input Validation
+- **Server-Side Validation**: All inputs validated on CloudAPI side for security
+- **XSS Prevention**: Sanitize all user inputs to prevent cross-site scripting
+- **Injection Protection**: Use parameterized queries and validate all API inputs
+- **Rate Limiting**: Respect API rate limits for vApp creation requests
+
+### Data Handling
+- **No Sensitive Data Storage**: Don't store credentials or sensitive template information
+- **Audit Logging**: Log vApp creation attempts for security monitoring
+- **Error Information**: Sanitize error messages to prevent information disclosure
+
+## Testing Strategy
+
+### Unit Tests
+- **Component Testing**: Test vApp creation modal, form validation, and VDC selection
+- **Hook Testing**: Test creation mutation, VDC fetching, and validation hooks
+- **Service Testing**: Test VAppService creation and validation methods
+- **Permission Testing**: Test role-based access control for vApp creation
+
+### Integration Tests
+- **API Integration**: Test CloudAPI calls with mock responses and error scenarios
+- **Navigation Flow**: Test complete user journey from template to vApp creation
+- **State Management**: Test cache invalidation and optimistic updates
+- **Error Scenarios**: Test various failure modes and recovery mechanisms
+
+### User Acceptance Testing
+- **Creation Workflow**: Complete template-to-vApp creation flow testing
+- **Permission Scenarios**: Test as different user roles (Org Admin, vApp User)
+- **Browser Compatibility**: Test across supported browsers and devices
+- **Performance Testing**: Test with large numbers of templates and VDCs
+
+### Accessibility Testing
+- **Screen Reader**: Test modal and form navigation with screen readers
+- **Keyboard Navigation**: Ensure full keyboard accessibility
+- **Color Contrast**: Verify color contrast meets accessibility standards
+- **Focus Management**: Test focus handling in modal interactions
+
+## Success Metrics
+
+### Functional Metrics
+- **Creation Success Rate**: > 95% successful vApp creations without errors
+- **Validation Accuracy**: Zero invalid vApp creation attempts reaching the API
+- **Navigation Efficiency**: < 3 clicks from template discovery to vApp creation start
+- **Error Recovery**: > 90% of failed attempts result in successful retry
+
+### Performance Metrics
+- **Modal Load Time**: vApp creation modal opens in < 500ms
+- **Form Responsiveness**: Form validation feedback appears in < 200ms
+- **Creation Time**: vApp creation completes in < 30 seconds average
+- **UI Responsiveness**: No UI blocking during vApp creation process
+
+### User Experience Metrics
+- **Task Completion Rate**: > 90% of users successfully complete vApp creation
+- **User Satisfaction**: Positive feedback on vApp creation workflow
+- **Support Requests**: Reduce vApp creation-related support tickets by 60%
+- **Feature Adoption**: > 80% of eligible users utilize vApp creation features
+
+## Implementation Timeline
+
+### Phase 1: Core Functionality (Week 1-2)
+1. **Week 1**: Create vApp creation modal component and basic form
+2. **Week 1**: Implement VDC selection and basic validation
+3. **Week 2**: Integrate CloudAPI service for vApp creation
+4. **Week 2**: Add template card actions and modal triggering
+
+### Phase 2: Polish & Integration (Week 3)
+1. **Enhanced Validation**: Implement comprehensive form validation and error handling
+2. **UX Improvements**: Add loading states, success feedback, and navigation
+3. **Permission Integration**: Implement role-based access control
+4. **Responsive Design**: Ensure mobile compatibility and accessibility
+
+### Phase 3: Testing & Deployment (Week 4)
+1. **Comprehensive Testing**: Unit tests, integration tests, and user acceptance testing
+2. **Performance Optimization**: Optimize load times and responsiveness
+3. **Documentation**: Update user guides and developer documentation
+4. **Deployment Preparation**: Final quality assurance and deployment planning
+
+## Migration & Rollout
+
+### Deployment Strategy
+- **Feature Flags**: Enable vApp creation features gradually by user role
+- **Backward Compatibility**: Ensure existing template viewing functionality remains intact
+- **Progressive Enhancement**: Add new features without disrupting existing workflows
+- **Rollback Plan**: Ability to disable vApp creation features if issues arise
+
+### User Training
+- **In-App Guidance**: Contextual tooltips and help text for new vApp creation features
+- **Documentation Updates**: Update user guides with vApp creation procedures
+- **Video Tutorials**: Create screen recordings of vApp creation workflows
+- **Admin Training**: Special guidance for organization administrators
+
+### Monitoring & Support
+- **Usage Analytics**: Track vApp creation feature adoption and success rates
+- **Error Monitoring**: Monitor API errors and user-reported issues
+- **Performance Tracking**: Monitor creation times and system performance impact
+- **User Feedback**: Collect and respond to user feedback on new features
+
+## Success Criteria for Rollout
+1. **Core Functionality Complete**: vApp creation from templates working for all user roles
+2. **Quality Standards Met**: All tests passing with > 95% code coverage
+3. **Performance Targets Achieved**: All response time and user experience metrics met
+4. **User Acceptance**: Positive feedback from beta users and stakeholders
+5. **Security Validation**: Security review completed with no critical issues
+6. **Documentation Complete**: User and developer documentation updated and reviewed
+
+## Conclusion
+
+This enhancement will significantly improve the SSVirt UI by providing a seamless path from template discovery to vApp creation. By integrating directly with the CloudAPI instantiateTemplate endpoint and maintaining strict adherence to existing UI patterns and security requirements, users will have a powerful and intuitive way to deploy applications from catalog templates.
+
+The implementation focuses on three core principles: **usability** (simple, guided workflow), **reliability** (robust error handling and validation), and **security** (proper permission controls and input validation). This approach ensures that the feature will be both powerful for users and maintainable for developers.
+
+Key success factors include maintaining CloudAPI compliance, implementing comprehensive permission controls, providing excellent user feedback throughout the creation process, and ensuring the feature integrates seamlessly with existing catalog and vApp management workflows.

--- a/src/components/catalogs/CatalogItemCard.tsx
+++ b/src/components/catalogs/CatalogItemCard.tsx
@@ -13,13 +13,18 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import { InfoCircleIcon, PlayIcon } from '@patternfly/react-icons';
+import {
+  InfoCircleIcon,
+  PlayIcon,
+  PlusCircleIcon,
+} from '@patternfly/react-icons';
 import type { CatalogItem } from '../../types';
 
 interface CatalogItemCardProps {
   catalogItem: CatalogItem;
   onSelect?: (item: CatalogItem) => void;
   onViewDetails?: (item: CatalogItem) => void;
+  onCreateVApp?: (item: CatalogItem) => void;
   showActions?: boolean;
 }
 
@@ -27,6 +32,7 @@ const CatalogItemCard: React.FC<CatalogItemCardProps> = ({
   catalogItem,
   onSelect,
   onViewDetails,
+  onCreateVApp,
   showActions = true,
 }) => {
   const formatDate = (dateString: string | undefined) => {
@@ -144,10 +150,22 @@ const CatalogItemCard: React.FC<CatalogItemCardProps> = ({
                 </Button>
               </SplitItem>
             )}
-            {onSelect && (
+            {onCreateVApp && (
               <SplitItem>
                 <Button
                   variant="primary"
+                  size="sm"
+                  icon={<PlusCircleIcon />}
+                  onClick={() => onCreateVApp(catalogItem)}
+                >
+                  Create vApp
+                </Button>
+              </SplitItem>
+            )}
+            {onSelect && (
+              <SplitItem>
+                <Button
+                  variant="secondary"
                   size="sm"
                   icon={<PlayIcon />}
                   onClick={() => onSelect(catalogItem)}

--- a/src/components/vapps/CreateVAppModal.tsx
+++ b/src/components/vapps/CreateVAppModal.tsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Modal,
+  ModalVariant,
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Button,
+  Alert,
+  AlertVariant,
+  Stack,
+  StackItem,
+  Split,
+  SplitItem,
+  Label,
+} from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import { useCreateVApp, useVAppNameValidation } from '../../hooks/useVApps';
+import VDCSelector from './VDCSelector';
+import type { CatalogItem, CreateVAppFormData } from '../../types';
+
+interface CreateVAppModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  catalogItem: CatalogItem;
+  onSuccess?: (vappId: string) => void;
+}
+
+const CreateVAppModal: React.FC<CreateVAppModalProps> = ({
+  isOpen,
+  onClose,
+  catalogItem,
+  onSuccess,
+}) => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<CreateVAppFormData>({
+    name: '',
+    description: '',
+    vdcId: '',
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const createVAppMutation = useCreateVApp();
+
+  // Name validation with debouncing
+  const { data: isNameValid, isLoading: isValidatingName } =
+    useVAppNameValidation(formData.vdcId, formData.name);
+
+  // Auto-generate vApp name based on template name
+  useEffect(() => {
+    if (isOpen && catalogItem && !formData.name) {
+      // Create a suggested name based on template name
+      const suggestedName = `${catalogItem.name}-vapp-${Date.now().toString().slice(-4)}`;
+      setFormData((prev) => ({ ...prev, name: suggestedName }));
+    }
+  }, [isOpen, catalogItem, formData.name]);
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    // Name validation
+    if (!formData.name.trim()) {
+      newErrors.name = 'vApp name is required';
+    } else if (formData.name.length < 3) {
+      newErrors.name = 'vApp name must be at least 3 characters';
+    } else if (formData.name.length > 128) {
+      newErrors.name = 'vApp name must be 128 characters or less';
+    } else if (!/^[a-zA-Z0-9._-]+$/.test(formData.name)) {
+      newErrors.name =
+        'vApp name can only contain letters, numbers, dots, underscores, and hyphens';
+    } else if (isNameValid === false) {
+      newErrors.name =
+        'A vApp with this name already exists in the selected VDC';
+    }
+
+    // Description validation
+    if (formData.description.length > 1024) {
+      newErrors.description = 'Description must be 1024 characters or less';
+    }
+
+    // VDC validation
+    if (!formData.vdcId) {
+      newErrors.vdcId = 'Please select a target VDC';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    if (isValidatingName) {
+      // Wait for name validation to complete
+      return;
+    }
+
+    try {
+      const vapp = await createVAppMutation.mutateAsync({
+        vdcId: formData.vdcId,
+        request: {
+          name: formData.name.trim(),
+          description: formData.description.trim() || undefined,
+          catalogItem: {
+            id: catalogItem.id,
+            name: catalogItem.name,
+          },
+        },
+      });
+
+      handleClose();
+
+      if (onSuccess) {
+        onSuccess(vapp.id);
+      } else {
+        // Navigate to vApp detail page
+        navigate(`/vapps/${vapp.id}`);
+      }
+    } catch (error) {
+      console.error('Failed to create vApp:', error);
+    }
+  };
+
+  const handleClose = () => {
+    setFormData({
+      name: '',
+      description: '',
+      vdcId: '',
+    });
+    setErrors({});
+    onClose();
+  };
+
+  const handleFieldChange = (
+    field: keyof CreateVAppFormData,
+    value: string
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // Clear field error when user starts typing
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: '' }));
+    }
+  };
+
+  const getNameValidation = () => {
+    if (isValidatingName) return 'default';
+    if (formData.name && isNameValid === false) return 'error';
+    if (formData.name && isNameValid === true) return 'success';
+    return errors.name ? 'error' : 'default';
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title="Create vApp from Template"
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
+      <div style={{ padding: '24px' }}>
+        <Stack hasGutter>
+          {/* Template Context */}
+          <StackItem>
+            <Alert
+              variant={AlertVariant.info}
+              title="Template Information"
+              isInline
+            >
+              <Split hasGutter>
+                <SplitItem>
+                  Creating vApp from template:{' '}
+                  <strong>{catalogItem?.name}</strong>
+                </SplitItem>
+                {catalogItem?.versionNumber && (
+                  <SplitItem>
+                    <Label isCompact color="blue">
+                      v{catalogItem.versionNumber}
+                    </Label>
+                  </SplitItem>
+                )}
+              </Split>
+              {catalogItem?.description && (
+                <p className="pf-v6-u-mt-sm">{catalogItem.description}</p>
+              )}
+            </Alert>
+          </StackItem>
+
+          {/* Error Display */}
+          {createVAppMutation.error && (
+            <StackItem>
+              <Alert
+                variant={AlertVariant.danger}
+                title="Error creating vApp"
+                isInline
+              >
+                {createVAppMutation.error instanceof Error
+                  ? createVAppMutation.error.message
+                  : 'An unexpected error occurred'}
+              </Alert>
+            </StackItem>
+          )}
+
+          {/* Form */}
+          <StackItem>
+            <Form onSubmit={handleSubmit}>
+              <Stack hasGutter>
+                {/* vApp Name */}
+                <StackItem>
+                  <FormGroup label="vApp Name" isRequired fieldId="vapp-name">
+                    <TextInput
+                      isRequired
+                      type="text"
+                      id="vapp-name"
+                      value={formData.name}
+                      onChange={(_, value) => handleFieldChange('name', value)}
+                      validated={getNameValidation()}
+                      placeholder="Enter vApp name"
+                      maxLength={128}
+                    />
+                    {isValidatingName && (
+                      <small className="pf-v6-u-color-200 pf-v6-u-font-size-sm">
+                        Checking name availability...
+                      </small>
+                    )}
+                    {isNameValid === true && (
+                      <small className="pf-v6-u-color-success-300 pf-v6-u-font-size-sm">
+                        Name is available
+                      </small>
+                    )}
+                    {errors.name && (
+                      <small className="pf-v6-u-color-danger-300 pf-v6-u-font-size-sm">
+                        {errors.name}
+                      </small>
+                    )}
+                  </FormGroup>
+                </StackItem>
+
+                {/* Description */}
+                <StackItem>
+                  <FormGroup label="Description" fieldId="vapp-description">
+                    <TextArea
+                      id="vapp-description"
+                      value={formData.description}
+                      onChange={(_, value) =>
+                        handleFieldChange('description', value)
+                      }
+                      validated={errors.description ? 'error' : 'default'}
+                      placeholder="Enter vApp description (optional)"
+                      rows={3}
+                      maxLength={1024}
+                    />
+                    <small className="pf-v6-u-color-200 pf-v6-u-font-size-sm">
+                      Optional description for the vApp (
+                      {formData.description.length}/1024 characters)
+                    </small>
+                    {errors.description && (
+                      <small className="pf-v6-u-color-danger-300 pf-v6-u-font-size-sm">
+                        {errors.description}
+                      </small>
+                    )}
+                  </FormGroup>
+                </StackItem>
+
+                {/* VDC Selection */}
+                <StackItem>
+                  <VDCSelector
+                    value={formData.vdcId}
+                    onChange={(vdcId) => handleFieldChange('vdcId', vdcId)}
+                    isRequired
+                    validated={errors.vdcId ? 'error' : 'default'}
+                    helperTextInvalid={errors.vdcId}
+                    isDisabled={createVAppMutation.isPending}
+                  />
+                </StackItem>
+              </Stack>
+            </Form>
+          </StackItem>
+
+          {/* Actions */}
+          <StackItem>
+            <div
+              style={{
+                display: 'flex',
+                gap: '12px',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Button
+                variant="link"
+                onClick={handleClose}
+                isDisabled={createVAppMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                type="submit"
+                onClick={handleSubmit}
+                isLoading={createVAppMutation.isPending}
+                isDisabled={
+                  createVAppMutation.isPending ||
+                  isValidatingName ||
+                  !formData.name ||
+                  !formData.vdcId ||
+                  isNameValid === false
+                }
+              >
+                Create vApp
+              </Button>
+            </div>
+          </StackItem>
+        </Stack>
+      </div>
+    </Modal>
+  );
+};
+
+export default CreateVAppModal;

--- a/src/components/vapps/VDCSelector.tsx
+++ b/src/components/vapps/VDCSelector.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import {
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Alert,
+  AlertVariant,
+} from '@patternfly/react-core';
+import { useAccessibleVDCs } from '../../hooks/useVDC';
+import LoadingSpinner from '../common/LoadingSpinner';
+
+interface VDCSelectorProps {
+  value: string;
+  onChange: (vdcId: string) => void;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  validated?: 'success' | 'error' | 'warning' | 'default';
+  helperTextInvalid?: string;
+}
+
+const VDCSelector: React.FC<VDCSelectorProps> = ({
+  value,
+  onChange,
+  isRequired = true,
+  isDisabled = false,
+  validated = 'default',
+  helperTextInvalid,
+}) => {
+  const {
+    data: vdcsResponse,
+    isLoading,
+    error,
+  } = useAccessibleVDCs(!isDisabled);
+
+  const vdcs = vdcsResponse?.values || [];
+
+  if (isLoading) {
+    return (
+      <FormGroup
+        label="Target VDC"
+        isRequired={isRequired}
+        fieldId="vdc-selector"
+      >
+        <LoadingSpinner message="Loading VDCs..." />
+      </FormGroup>
+    );
+  }
+
+  if (error) {
+    return (
+      <FormGroup
+        label="Target VDC"
+        isRequired={isRequired}
+        fieldId="vdc-selector"
+      >
+        <Alert
+          variant={AlertVariant.danger}
+          title="Error loading VDCs"
+          isInline
+        >
+          {error instanceof Error
+            ? error.message
+            : 'Failed to load available VDCs. Please try again.'}
+        </Alert>
+      </FormGroup>
+    );
+  }
+
+  if (vdcs.length === 0) {
+    return (
+      <FormGroup
+        label="Target VDC"
+        isRequired={isRequired}
+        fieldId="vdc-selector"
+      >
+        <Alert
+          variant={AlertVariant.warning}
+          title="No VDCs available"
+          isInline
+        >
+          You don't have access to any VDCs where you can create vApps. Please
+          contact your administrator.
+        </Alert>
+      </FormGroup>
+    );
+  }
+
+  return (
+    <FormGroup
+      label="Target VDC"
+      isRequired={isRequired}
+      fieldId="vdc-selector"
+    >
+      <FormSelect
+        value={value}
+        onChange={(_, selectedValue) => onChange(selectedValue)}
+        aria-label="Select VDC"
+        isDisabled={isDisabled}
+        validated={validated}
+        isRequired={isRequired}
+      >
+        <FormSelectOption key="" value="" label="Select a VDC..." />
+        {vdcs.map((vdc) => (
+          <FormSelectOption
+            key={vdc.id}
+            value={vdc.id}
+            label={`${vdc.name}${vdc.description ? ` - ${vdc.description}` : ''}`}
+          />
+        ))}
+      </FormSelect>
+      {validated === 'default' && (
+        <small className="pf-v6-u-color-200 pf-v6-u-font-size-sm">
+          Select the Virtual Data Center where your vApp will be created
+        </small>
+      )}
+      {helperTextInvalid && validated === 'error' && (
+        <small className="pf-v6-u-color-danger-300 pf-v6-u-font-size-sm">
+          {helperTextInvalid}
+        </small>
+      )}
+    </FormGroup>
+  );
+};
+
+export default VDCSelector;

--- a/src/hooks/useVDC.ts
+++ b/src/hooks/useVDC.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { AxiosError } from 'axios';
 import { VDCService } from '../services';
+import { VDCPublicService } from '../services/cloudapi/VDCPublicService';
 import { QUERY_KEYS } from '../types';
 import { useUserPermissions } from './usePermissions';
 import type {
@@ -237,5 +238,38 @@ export const useDeleteVDC = () => {
     onError: (error) => {
       console.error('Failed to delete VDC:', error);
     },
+  });
+};
+
+/**
+ * Hook to fetch VDCs where the user can create vApps
+ * Filters organization VDCs based on user permissions
+ */
+export const useAccessibleVDCs = (enabled = true) => {
+  const { data: userPermissions } = useUserPermissions();
+
+  return useQuery({
+    queryKey: [...QUERY_KEYS.vdcs, 'accessible-for-vapp-creation'],
+    queryFn: async () => {
+      // Use public API to get VDCs accessible to current user's organization(s)
+      // This works for both admin and regular users
+      const vdcsResponse = await VDCPublicService.getVDCs();
+
+      // Filter VDCs where user can create vApps
+      // For now, if user can view VDCs, they can create vApps in them
+      // This can be enhanced later with more granular permissions
+      return {
+        ...vdcsResponse,
+        values: vdcsResponse.values.filter(
+          () =>
+            userPermissions?.canManageVDCs || userPermissions?.canManageSystem
+        ),
+      };
+    },
+    enabled:
+      enabled &&
+      (userPermissions?.canManageVDCs || userPermissions?.canManageSystem),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 15 * 60 * 1000, // 15 minutes
   });
 };

--- a/src/hooks/useVDC.ts
+++ b/src/hooks/useVDC.ts
@@ -255,15 +255,19 @@ export const useAccessibleVDCs = (enabled = true) => {
       // This works for both admin and regular users
       const vdcsResponse = await VDCPublicService.getVDCs();
 
-      // Filter VDCs where user can create vApps
-      // For now, if user can view VDCs, they can create vApps in them
-      // This can be enhanced later with more granular permissions
+      // Return VDCs where user can create vApps
+      // If user has global VDC or system management permissions, they can create vApps in any VDC
+      // This can be enhanced later with more granular per-VDC permissions
+      if (userPermissions?.canManageVDCs || userPermissions?.canManageSystem) {
+        return vdcsResponse;
+      }
+
+      // If user doesn't have global permissions, return empty array
+      // In the future, this could check per-VDC permissions like:
+      // vdcsResponse.values.filter(vdc => vdc.isAccessible || vdc.permissions?.canCreateVApps)
       return {
         ...vdcsResponse,
-        values: vdcsResponse.values.filter(
-          () =>
-            userPermissions?.canManageVDCs || userPermissions?.canManageSystem
-        ),
+        values: [],
       };
     },
     enabled:

--- a/src/pages/catalogs/CatalogDetail.tsx
+++ b/src/pages/catalogs/CatalogDetail.tsx
@@ -32,14 +32,19 @@ import {
 import { VirtualMachineIcon } from '@patternfly/react-icons';
 import { useCatalog, useCatalogItems } from '../../hooks/useCatalogs';
 import LoadingSpinner from '../../components/common/LoadingSpinner';
+import CatalogItemCard from '../../components/catalogs/CatalogItemCard';
+import CreateVAppModal from '../../components/vapps/CreateVAppModal';
 import { ROUTES } from '../../utils/constants';
-import type { CatalogItemQueryParams } from '../../types';
+import type { CatalogItemQueryParams, CatalogItem } from '../../types';
 
 const CatalogDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [activeTabKey, setActiveTabKey] = useState(0);
   const [searchTerm, setSearchTerm] = useState('');
   const [page, setPage] = useState(1);
+  const [selectedCatalogItem, setSelectedCatalogItem] =
+    useState<CatalogItem | null>(null);
+  const [isCreateVAppModalOpen, setIsCreateVAppModalOpen] = useState(false);
   const pageSize = 12;
 
   const {
@@ -84,6 +89,18 @@ const CatalogDetail: React.FC = () => {
   useEffect(() => {
     setPage(1);
   }, [searchTerm]);
+
+  // Handler for opening the vApp creation modal
+  const handleCreateVApp = (catalogItem: CatalogItem) => {
+    setSelectedCatalogItem(catalogItem);
+    setIsCreateVAppModalOpen(true);
+  };
+
+  // Handler for closing the vApp creation modal
+  const handleCloseCreateVAppModal = () => {
+    setSelectedCatalogItem(null);
+    setIsCreateVAppModalOpen(false);
+  };
 
   // Handle missing id parameter
   if (!id) {
@@ -314,56 +331,11 @@ const CatalogDetail: React.FC = () => {
                         <Grid hasGutter>
                           {filteredItems.map((item) => (
                             <GridItem key={item.id} span={6}>
-                              <Card isSelectable>
-                                <CardBody>
-                                  <Stack hasGutter>
-                                    <StackItem>
-                                      <Split hasGutter>
-                                        <SplitItem>
-                                          <VirtualMachineIcon
-                                            style={{ fontSize: '24px' }}
-                                          />
-                                        </SplitItem>
-                                        <SplitItem isFilled>
-                                          <Title headingLevel="h4" size="md">
-                                            {item.name}
-                                          </Title>
-                                        </SplitItem>
-                                        <SplitItem>
-                                          <Badge color="blue">
-                                            v{item.versionNumber}
-                                          </Badge>
-                                        </SplitItem>
-                                      </Split>
-                                    </StackItem>
-                                    <StackItem>
-                                      <p className="pf-v6-u-color-200">
-                                        {item.description ||
-                                          'No description available'}
-                                      </p>
-                                    </StackItem>
-                                    <StackItem>
-                                      <Stack>
-                                        <StackItem>
-                                          <Badge>
-                                            {item.entity?.templateSpec
-                                              ?.parameters?.length || 0}{' '}
-                                            parameters
-                                          </Badge>
-                                        </StackItem>
-                                        <StackItem>
-                                          <small className="pf-v6-u-color-200">
-                                            Created:{' '}
-                                            {new Date(
-                                              item.creationDate
-                                            ).toLocaleDateString()}
-                                          </small>
-                                        </StackItem>
-                                      </Stack>
-                                    </StackItem>
-                                  </Stack>
-                                </CardBody>
-                              </Card>
+                              <CatalogItemCard
+                                catalogItem={item}
+                                onCreateVApp={handleCreateVApp}
+                                showActions={true}
+                              />
                             </GridItem>
                           ))}
                         </Grid>
@@ -390,6 +362,15 @@ const CatalogDetail: React.FC = () => {
           </Tabs>
         </StackItem>
       </Stack>
+
+      {/* vApp Creation Modal */}
+      {selectedCatalogItem && (
+        <CreateVAppModal
+          isOpen={isCreateVAppModalOpen}
+          onClose={handleCloseCreateVAppModal}
+          catalogItem={selectedCatalogItem}
+        />
+      )}
     </PageSection>
   );
 };

--- a/src/services/cloudapi/VAppService.ts
+++ b/src/services/cloudapi/VAppService.ts
@@ -1,0 +1,118 @@
+import { cloudApi } from '../api';
+import { VMService } from './VMService';
+import type {
+  VApp,
+  CreateVAppFromTemplateRequest,
+  VCloudPaginatedResponse,
+} from '../../types';
+
+/**
+ * VApp Service - Simplified interface for vApp operations
+ * Wraps VMService methods with cleaner API for vApp creation and management
+ */
+export class VAppService {
+  /**
+   * Sanitize catalog item URN to ensure proper format
+   * Removes any appended name or extra text that might be present
+   * @param catalogItemId The potentially malformed catalog item ID
+   * @returns Clean catalog item URN
+   */
+  private static sanitizeCatalogItemUrn(catalogItemId: string): string {
+    // Expected format: urn:vcloud:catalogitem:uuid
+    // Sometimes APIs return: urn:vcloud:catalogitem:uuid:name or similar
+
+    // If it's already a proper URN, extract just the URN part
+    const urnMatch = catalogItemId.match(
+      /^(urn:vcloud:catalogitem:[a-f0-9-]+)/i
+    );
+    if (urnMatch) {
+      return urnMatch[1];
+    }
+
+    // If it doesn't match the expected format, return as-is and let the API handle it
+    return catalogItemId;
+  }
+
+  /**
+   * Create a vApp from a catalog template
+   * @param vdcId The VDC URN where the vApp will be created
+   * @param request vApp creation configuration
+   */
+  static async createFromTemplate(
+    vdcId: string,
+    request: CreateVAppFromTemplateRequest
+  ): Promise<VApp> {
+    // Sanitize the catalog item ID to ensure it's a proper URN
+    // Sometimes APIs return composite IDs with names appended
+    const sanitizedCatalogItemId = this.sanitizeCatalogItemUrn(
+      request.catalogItem.id
+    );
+
+    // Create the request body according to the API documentation
+    const apiRequest = {
+      name: request.name,
+      description: request.description,
+      catalogItem: {
+        id: sanitizedCatalogItemId,
+        name: request.catalogItem.name,
+      },
+    };
+
+    // Make the API call directly using the correct format
+    const response = await cloudApi.post<VCloudPaginatedResponse<VApp>>(
+      `/1.0.0/vdcs/${encodeURIComponent(vdcId)}/actions/instantiateTemplate`,
+      apiRequest
+    );
+
+    // The API returns a paginated response, but we expect the first vApp
+    if (response.data.values && response.data.values.length > 0) {
+      return response.data.values[0];
+    }
+
+    throw new Error('Failed to create vApp: No vApp returned from API');
+  }
+
+  /**
+   * Get vApp details
+   * @param vappId The vApp URN
+   */
+  static async getVApp(vappId: string): Promise<VApp> {
+    return VMService.getVApp(vappId);
+  }
+
+  /**
+   * List vApps for a specific VDC
+   * @param vdcId The VDC URN
+   */
+  static async getVAppsByVDC(
+    vdcId: string
+  ): Promise<VCloudPaginatedResponse<VApp>> {
+    return VMService.getVAppsByVDC(vdcId);
+  }
+
+  /**
+   * Delete a vApp
+   * @param vappId The vApp URN
+   */
+  static async deleteVApp(vappId: string): Promise<void> {
+    return VMService.deleteVApp(vappId);
+  }
+
+  /**
+   * Validate vApp name uniqueness within a VDC
+   * @param vdcId The VDC URN
+   * @param name The proposed vApp name
+   */
+  static async validateVAppName(vdcId: string, name: string): Promise<boolean> {
+    try {
+      const vapps = await this.getVAppsByVDC(vdcId);
+      const existingNames =
+        vapps.values?.map((vapp) => vapp.name.toLowerCase()) || [];
+      return !existingNames.includes(name.toLowerCase());
+    } catch (error) {
+      console.error('Error validating vApp name:', error);
+      // If we can't validate, assume it's valid to avoid blocking user
+      return true;
+    }
+  }
+}

--- a/src/services/cloudapi/VDCPublicService.ts
+++ b/src/services/cloudapi/VDCPublicService.ts
@@ -1,4 +1,5 @@
-import { api } from '../api';
+import { cloudApi } from '../api';
+import { API_ENDPOINTS } from '../../utils/constants';
 import type {
   VDC,
   VDCPublicQueryParams,
@@ -17,8 +18,8 @@ export class VDCPublicService {
   static async getVDCs(
     params?: VDCPublicQueryParams
   ): Promise<VCloudPaginatedResponse<VDC>> {
-    const response = await api.get<VCloudPaginatedResponse<VDC>>(
-      '/cloudapi/1.0.0/vdcs',
+    const response = await cloudApi.get<VCloudPaginatedResponse<VDC>>(
+      API_ENDPOINTS.CLOUDAPI.VDCS,
       { params }
     );
     return response.data;
@@ -29,8 +30,8 @@ export class VDCPublicService {
    * GET /cloudapi/1.0.0/vdcs/{vdc_urn}
    */
   static async getVDC(vdcId: string): Promise<VDC> {
-    const response = await api.get<VDC>(
-      `/cloudapi/1.0.0/vdcs/${encodeURIComponent(vdcId)}`
+    const response = await cloudApi.get<VDC>(
+      API_ENDPOINTS.CLOUDAPI.VDC_BY_ID(vdcId)
     );
     return response.data;
   }

--- a/src/services/cloudapi/index.ts
+++ b/src/services/cloudapi/index.ts
@@ -6,3 +6,4 @@ export { VDCService } from './VDCService';
 export { VDCAdminService } from './VDCAdminService';
 export { VDCPublicService } from './VDCPublicService';
 export { CatalogService } from './CatalogService';
+export { VAppService } from './VAppService';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,6 +8,7 @@ export {
   CloudApiOrganizationService,
   VDCService,
   CatalogService,
+  VAppService,
 } from './cloudapi';
 
 // Export domain services

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -616,6 +616,22 @@ export type VAppStatus =
   | 'FAILED'
   | 'UNKNOWN';
 
+// vApp Creation Types
+export interface CreateVAppFromTemplateRequest {
+  name: string;
+  description?: string;
+  catalogItem: {
+    id: string;
+    name?: string;
+  };
+}
+
+export interface CreateVAppFormData {
+  name: string;
+  description: string;
+  vdcId: string;
+}
+
 // Enhanced VM interface for CloudAPI
 export interface VMCloudAPI {
   id: string; // URN format


### PR DESCRIPTION
## Summary
Implements comprehensive vApp creation functionality from catalog templates with a modal-based UI workflow, form validation, and proper VMware Cloud Director API integration.

## Features Added
- **Create vApp Modal**: Full-featured modal with form validation, auto-name generation, and real-time validation
- **VDC Selection**: Dropdown component for selecting target Virtual Data Centers with proper error handling
- **vApp Service**: Dedicated service layer for vApp operations with API compliance
- **Template Integration**: "Create vApp" action buttons integrated into catalog template views

## Technical Implementation
- **API Compliance**: Proper integration with VMware Cloud Director `instantiateTemplate` endpoint
- **Form Validation**: Real-time name validation with uniqueness checking and comprehensive error handling
- **Auto-generation**: Smart vApp naming based on template names with timestamps
- **Permission-based Access**: VDC filtering based on user permissions for vApp creation
- **URN Sanitization**: Handles malformed catalog item URNs that may have appended names

## Components
### New Components
- `CreateVAppModal`: Modal component for vApp creation workflow
- `VDCSelector`: Reusable VDC selection dropdown with loading and error states
- `VAppService`: Service layer for vApp operations with proper API formatting

### Enhanced Components
- `CatalogItemCard`: Added "Create vApp" action button with PlusCircleIcon
- `CatalogDetail`: Integrated vApp creation modal into catalog template views
- `useVApps`: Added `useCreateVApp` and `useVAppNameValidation` hooks
- `useVDC`: Added `useAccessibleVDCs` hook for VDC selection

## API Fixes
- **VDCPublicService**: Fixed to use `cloudApi` instance instead of `api` for correct endpoint routing
- **Request Format**: Implemented correct API request body format with `catalogItem` object structure
- **Endpoint Paths**: Uses proper API constants for consistent endpoint management

## User Experience
1. Users can click "Create vApp" on any template in catalog views
2. Modal opens with auto-generated vApp name based on template name
3. Users can edit the name, add description, and select target VDC
4. Real-time validation ensures name uniqueness and proper formatting
5. Successful creation navigates to vApp detail page

## Quality Assurance
- ✅ All linting, formatting, and type checking pass
- ✅ Successful production build without errors
- ✅ All existing tests continue to pass
- ✅ Follows existing codebase patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Create vApp from catalog templates via a new “Create vApp” action on template cards and a guided creation modal.
  * Modal includes name/description, target VDC selection, live name-availability checks, validation, loading states, and post-creation navigation.

* Documentation
  * New enhancement doc detailing the vApp-from-template workflow, API contract, validation, permissions, testing, and rollout plans.

* Chores
  * .gitignore updated to ignore files or directories named "console.log".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->