### PR TITLE
Fix catalog creation functionality for System Administrators

### DIFF
--- a/src/components/catalogs/CreateCatalogModal.tsx
+++ b/src/components/catalogs/CreateCatalogModal.tsx
@@ -63,11 +63,15 @@ const CreateCatalogModal: React.FC<CreateCatalogModalProps> = ({
   };
 
   const handleSubmit = async (event: React.FormEvent) => {
+    console.log('Create Catalog form submitted!');
     event.preventDefault();
 
     if (!validateForm()) {
+      console.log('Form validation failed');
       return;
     }
+
+    console.log('Form validation passed, creating catalog...');
 
     const createRequest: CreateCatalogRequest = {
       name: formData.name.trim(),
@@ -214,34 +218,35 @@ const CreateCatalogModal: React.FC<CreateCatalogModalProps> = ({
                     </small>
                   </FormGroup>
                 </StackItem>
+
+                {/* Form Buttons */}
+                <StackItem>
+                  <div
+                    style={{
+                      display: 'flex',
+                      gap: '12px',
+                      justifyContent: 'flex-end',
+                    }}
+                  >
+                    <Button
+                      variant="link"
+                      onClick={handleClose}
+                      isDisabled={createCatalogMutation.isPending}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="primary"
+                      type="submit"
+                      isLoading={createCatalogMutation.isPending}
+                      isDisabled={createCatalogMutation.isPending}
+                    >
+                      Create Catalog
+                    </Button>
+                  </div>
+                </StackItem>
               </Stack>
             </Form>
-          </StackItem>
-
-          <StackItem>
-            <div
-              style={{
-                display: 'flex',
-                gap: '12px',
-                justifyContent: 'flex-end',
-              }}
-            >
-              <Button
-                variant="link"
-                onClick={handleClose}
-                isDisabled={createCatalogMutation.isPending}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                type="submit"
-                isLoading={createCatalogMutation.isPending}
-                isDisabled={createCatalogMutation.isPending}
-              >
-                Create Catalog
-              </Button>
-            </div>
           </StackItem>
         </Stack>
       </div>


### PR DESCRIPTION
## Summary
Fixes the catalog creation bug where clicking the "Create Catalog" button in the modal did nothing for System Administrators.

## Root Cause
The issue had two parts:
1. **Missing UI Components**: The Catalogs page was missing the "Create Catalog" button and modal integration
2. **Broken Form Submission**: The submit button in CreateCatalogModal was positioned outside the form element

## Changes Made

### Catalogs Page (`src/pages/catalogs/Catalogs.tsx`)
- Added "Create Catalog" button to toolbar (visible only to System Admins)
- Integrated CreateCatalogModal component
- Added organization context handling for System Administrators
- Implemented organization selection logic (defaults to first available organization)

### CreateCatalogModal (`src/components/catalogs/CreateCatalogModal.tsx`)
- **Critical Fix**: Moved submit and cancel buttons inside the Form component
- Added debug logging for form submission troubleshooting
- Maintained existing visual layout and styling

## Test Plan
- [x] Verify "Create Catalog" button appears for System Administrators
- [x] Verify button opens the catalog creation modal
- [x] Verify form submission works when clicking "Create Catalog" in modal
- [x] Verify console output shows form submission events
- [x] Verify HTTP requests are made to the catalog creation API
- [x] All tests, linting, and formatting checks pass

## API Compliance
- Uses existing CreateCatalogModal component and API integration
- Follows VMware Cloud Director CloudAPI patterns
- Proper organization context handling for multi-tenant environments

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Create Catalog action on the Catalogs page, available to system administrators.
  * Introduced a modal to create catalogs with organization preselection (defaults to the first available organization).
  * Toolbar shows the Create Catalog button only when permitted.
* **Refactor**
  * Improved the Create Catalog form layout by moving action buttons inside the form and adding proper loading/disabled states during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->