### PR TITLE
Fix vApp creation modal response parsing bug

### DIFF
--- a/src/components/vms/VMCreationWizard.tsx
+++ b/src/components/vms/VMCreationWizard.tsx
@@ -237,8 +237,8 @@ const VMCreationWizard: React.FC<VMCreationWizardProps> = ({
       });
 
       // Set the created vApp ID for progress monitoring
-      if (response.values?.[0]?.id) {
-        setCreatedVAppId(response.values[0].id);
+      if (response.id) {
+        setCreatedVAppId(response.id);
       }
 
       setShowProgress(true);

--- a/src/hooks/useCloudAPIVMs.ts
+++ b/src/hooks/useCloudAPIVMs.ts
@@ -115,11 +115,8 @@ export const useInstantiateTemplate = () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.vapps });
 
       // Cache the new vApp
-      if (response.values?.[0]) {
-        queryClient.setQueryData(
-          QUERY_KEYS.vapp(response.values[0].id),
-          response.values[0]
-        );
+      if (response.id) {
+        queryClient.setQueryData(QUERY_KEYS.vapp(response.id), response);
       }
     },
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -744,8 +744,8 @@ export const handlers = [
       // Add to store for consistent access
       vappStore.push(vapp);
 
-      return HttpResponse.json(createCloudApiPaginatedResponse([vapp], 1, 25), {
-        status: 202,
+      return HttpResponse.json(vapp, {
+        status: 201,
       });
     }
   ),

--- a/src/services/cloudapi/VAppService.ts
+++ b/src/services/cloudapi/VAppService.ts
@@ -59,14 +59,14 @@ export class VAppService {
     };
 
     // Make the API call directly using the correct format
-    const response = await cloudApi.post<VCloudPaginatedResponse<VApp>>(
+    const response = await cloudApi.post<VApp>(
       `/1.0.0/vdcs/${encodeURIComponent(vdcId)}/actions/instantiateTemplate`,
       apiRequest
     );
 
-    // The API returns a paginated response, but we expect the first vApp
-    if (response.data.values && response.data.values.length > 0) {
-      return response.data.values[0];
+    // The API returns a single vApp object, not a paginated collection
+    if (response.data && response.data.id) {
+      return response.data;
     }
 
     throw new Error('Failed to create vApp: No vApp returned from API');

--- a/src/services/cloudapi/VMService.ts
+++ b/src/services/cloudapi/VMService.ts
@@ -60,8 +60,8 @@ export class VMService {
   static async instantiateTemplate(
     vdcId: string,
     request: InstantiateTemplateRequest
-  ): Promise<VCloudPaginatedResponse<VApp>> {
-    const response = await cloudApi.post<VCloudPaginatedResponse<VApp>>(
+  ): Promise<VApp> {
+    const response = await cloudApi.post<VApp>(
       `/1.0.0/vdcs/${encodeURIComponent(vdcId)}/actions/instantiateTemplate`,
       request
     );


### PR DESCRIPTION
## Summary

Fixes the vApp creation modal bug where users saw "Failed to create vApp. No vApp returned from API" error message despite successful API responses.

## Root Cause

The `VAppService.createFromTemplate` method was incorrectly expecting a `VCloudPaginatedResponse<VApp>` from the `instantiateTemplate` API endpoint, but according to the API reference, this endpoint returns a **single vApp object** with a `201 Created` status, not a paginated collection.

## Changes Made

### VAppService.ts
- Changed response type from `VCloudPaginatedResponse<VApp>` to `VApp`
- Updated response parsing from `response.data.values[0]` to `response.data`
- Updated validation to check for `response.data.id` instead of `values` array

### Mock Handlers
- Changed mock response from `createCloudApiPaginatedResponse([vapp], 1, 25)` to direct `vapp` object  
- Updated HTTP status from `202` to `201` to match API specification

## API Specification Compliance

According to the API reference, the `instantiateTemplate` endpoint returns:
- **Status**: `201 Created`
- **Body**: Single vApp object (not paginated)

## Test Plan

- [ ] Verify vApp creation modal no longer shows error message
- [ ] Confirm vApp creation succeeds and navigates to vApp detail page
- [ ] Check that created vApp appears in vApp listings
- [ ] Ensure build and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - vApp creation from templates now returns the created vApp object directly (201 Created) for faster, clearer results.
- Bug Fixes
  - Fixed inconsistent instantiation responses by removing paginated envelopes and delivering the actual vApp payload.
  - Improved client caching and success handling to use the returned vApp id and payload reliably.
- Chores
  - Aligned service and client behavior for consistent vApp instantiation across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->