### PR TITLE
Implement session persistence for Virtual Applications view

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -163,3 +163,6 @@ export {
   useVisibilityAwarePolling,
   useAutoRefreshState,
 } from './useVisibilityAwarePolling';
+
+// Export session storage hooks
+export { useSessionStorage, useVAppsSessionFilters } from './useSessionStorage';

--- a/src/hooks/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Custom hook for managing session storage with type safety
+ * Provides automatic persistence and retrieval of values
+ */
+export function useSessionStorage<T>(
+  key: string,
+  defaultValue: T
+): [T, (value: T | ((prev: T) => T)) => void, () => void] {
+  // Initialize state with value from session storage or default
+  const [state, setState] = useState<T>(() => {
+    try {
+      const item = sessionStorage.getItem(key);
+      return item ? JSON.parse(item) : defaultValue;
+    } catch (error) {
+      console.warn(`Failed to load session storage item "${key}":`, error);
+      return defaultValue;
+    }
+  });
+
+  // Update session storage when state changes
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(state));
+    } catch (error) {
+      console.warn(`Failed to save session storage item "${key}":`, error);
+    }
+  }, [key, state]);
+
+  // Function to update state (supports functional updates)
+  const setValue = useCallback((value: T | ((prev: T) => T)) => {
+    setState((prev) => {
+      const newValue =
+        typeof value === 'function' ? (value as (prev: T) => T)(prev) : value;
+      return newValue;
+    });
+  }, []);
+
+  // Function to clear the stored value
+  const clearValue = useCallback(() => {
+    try {
+      sessionStorage.removeItem(key);
+      setState(defaultValue);
+    } catch (error) {
+      console.warn(`Failed to remove session storage item "${key}":`, error);
+    }
+  }, [key, defaultValue]);
+
+  return [state, setValue, clearValue];
+}
+
+/**
+ * Hook specifically for managing vApps view filter persistence
+ * Handles organization and VDC selections with automatic restoration
+ */
+export function useVAppsSessionFilters() {
+  const [persistedFilters, setPersisted, clearPersisted] = useSessionStorage(
+    'vapps-view-filters',
+    {
+      org_id: '',
+      vdc_id: '',
+    }
+  );
+
+  const updateOrganization = useCallback(
+    (org_id: string) => {
+      setPersisted((prev) => ({
+        ...prev,
+        org_id,
+        // Clear VDC when organization changes
+        vdc_id: '',
+      }));
+    },
+    [setPersisted]
+  );
+
+  const updateVDC = useCallback(
+    (vdc_id: string) => {
+      setPersisted((prev) => ({
+        ...prev,
+        vdc_id,
+      }));
+    },
+    [setPersisted]
+  );
+
+  const clearSession = useCallback(() => {
+    clearPersisted();
+  }, [clearPersisted]);
+
+  return {
+    persistedFilters,
+    updateOrganization,
+    updateVDC,
+    clearSession,
+  };
+}

--- a/src/pages/vms/VMs.tsx
+++ b/src/pages/vms/VMs.tsx
@@ -246,13 +246,6 @@ const VMs: React.FC = () => {
     }
   }, [filters.org_id, vdcs, filters.vdc_id, updateVDC]);
 
-  // Clear VDC when organization changes
-  useEffect(() => {
-    if (filters.org_id !== persistedFilters.org_id) {
-      setFilters((prev) => ({ ...prev, vdc_id: persistedFilters.vdc_id }));
-    }
-  }, [persistedFilters.org_id, persistedFilters.vdc_id, filters.org_id]);
-
   // Clear selections when filters change
   useEffect(() => {
     setSelectedVApps([]);
@@ -261,10 +254,15 @@ const VMs: React.FC = () => {
   const handleFilterChange = (key: keyof VAppFilters, value: string) => {
     if (key === 'org_id') {
       updateOrganization(value);
+      // Clear VDC when organization changes
+      updateVDC('');
+      setFilters((prev) => ({ ...prev, org_id: value, vdc_id: '' }));
     } else if (key === 'vdc_id') {
       updateVDC(value);
+      setFilters((prev) => ({ ...prev, [key]: value }));
+    } else {
+      setFilters((prev) => ({ ...prev, [key]: value }));
     }
-    setFilters((prev) => ({ ...prev, [key]: value }));
   };
 
   const handleClearFilters = () => {


### PR DESCRIPTION
## Summary
• Add session storage hook with type safety for persisting user selections
• Integrate session persistence into Virtual Applications view for org and VDC filters  
• Auto-select VDC when organization has only one VDC available
• Clear VDC selection when organization changes for better UX

## Test plan
- [ ] Verify org and VDC selections persist across browser refresh/navigation
- [ ] Test auto-selection works when org has single VDC
- [ ] Confirm VDC clears when switching organizations
- [ ] Check session storage handles edge cases (localStorage disabled, parse errors)
- [ ] Validate TypeScript compilation and linting pass
- [ ] Test build process completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM filters persist for the browser session—Organization and VDC selections are remembered across reloads in the same tab and initialize the filters on load.

* **Improvements**
  * When an Organization has exactly one VDC, it’s auto-selected.
  * Changing the Organization clears the VDC to avoid mismatches.
  * “Clear filters” also clears saved choices for a consistent reset experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->