### PR TITLE
Fix SPA routing 404 errors on page reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "preview": "vite preview",
-    "serve": "serve dist -l 8080"
+    "serve": "npx serve dist -l 8080 -s"
   },
   "dependencies": {
     "@patternfly/react-core": "^6.3.1",

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,6 @@
+{
+  "public": "dist",
+  "rewrites": [
+    { "source": "**", "destination": "/index.html" }
+  ]
+}

--- a/test-spa-routing.md
+++ b/test-spa-routing.md
@@ -1,0 +1,31 @@
+# Testing SPA Routing Fix
+
+## How to test the fix
+
+1. Build the application:
+   ```bash
+   npm run build
+   ```
+
+2. Serve the application:
+   ```bash
+   npm run serve
+   ```
+
+3. Test direct navigation to routes:
+   - Open browser to `http://localhost:8080/dashboard` - should load dashboard
+   - Open browser to `http://localhost:8080/vms` - should load VMs page
+   - Open browser to `http://localhost:8080/organizations` - should load organizations page
+   - Any other route should also work without 404 errors
+
+## What was fixed
+
+The issue was that the `serve` package was not configured for Single Page Application (SPA) routing. When users navigated directly to URLs like `/dashboard`, the server would look for a file at that path instead of serving the main `index.html` file and letting React Router handle the routing.
+
+The fix adds the `-s` (single) flag to the serve command, which rewrites all not-found requests to `index.html`, allowing React Router to handle client-side routing properly.
+
+## Technical details
+
+- **Before**: `serve dist -l 8080` - would return 404 for routes like `/dashboard`
+- **After**: `serve dist -l 8080 -s` - falls back to `index.html` for all routes
+- **Alternative**: Created `serve.json` config file for more complex configurations if needed


### PR DESCRIPTION
## Summary
Fixes issue #53 where direct navigation or page reloads to any route (like `/dashboard`, `/vms`, etc.) would result in 404 errors or blank pages.

## Problem
The application uses React Router with `BrowserRouter` for client-side routing, but the server wasn't configured to handle Single Page Application (SPA) routing. When users:
- Navigated directly to a URL like `http://localhost:8080/dashboard`
- Refreshed the page on any route other than `/`

The server would look for a file at that path instead of serving the main `index.html` file, resulting in 404 errors.

## Solution
Configure the `serve` package to enable SPA mode by adding the `-s` (single) flag, which rewrites all not-found requests to `index.html`, allowing React Router to handle client-side routing properly.

## Changes
- **Updated `package.json`**: Modified serve command from `serve dist -l 8080` to `serve dist -l 8080 -s`
- **Added `serve.json`**: Configuration file for alternative/advanced server setup if needed
- **Added `test-spa-routing.md`**: Documentation with testing instructions and technical details

## Testing
1. Build the application: `npm run build`
2. Serve the application: `npm run serve`
3. Test direct navigation:
   - ✅ `http://localhost:8080/dashboard` - should load dashboard
   - ✅ `http://localhost:8080/vms` - should load VMs page  
   - ✅ `http://localhost:8080/organizations` - should load organizations page
   - ✅ Any other route should work without 404 errors
4. Test page refresh on any route - should work correctly

## Technical Details
- **Before**: Server returned 404 for client-side routes
- **After**: Server falls back to `index.html` for all routes, letting React Router handle navigation
- **Flag used**: `-s` tells serve to rewrite all not-found requests to `index.html`
- **Compatible**: Works with existing build process and deployment

## Impact
- ✅ **No more 404 errors** on direct navigation or page refresh
- ✅ **Better user experience** - all routes are directly accessible
- ✅ **SEO friendly** - proper URL handling for bookmarks and sharing
- ✅ **Production ready** - standard SPA server configuration

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/code)