### PR TITLE
Fix vApps table columns - remove Organization and fix Status display

### DIFF
--- a/src/pages/vms/VMs.tsx
+++ b/src/pages/vms/VMs.tsx
@@ -220,7 +220,7 @@ const VMs: React.FC = () => {
   // Calculate totals
   const totalVApps = filteredVApps.length;
   const totalVMs = filteredVApps.reduce(
-    (sum, vApp) => sum + (vApp.vms?.length || 0),
+    (sum, vApp) => sum + (vApp.numberOfVMs || vApp.vms?.length || 0),
     0
   );
 

--- a/src/pages/vms/VMs.tsx
+++ b/src/pages/vms/VMs.tsx
@@ -220,7 +220,7 @@ const VMs: React.FC = () => {
   // Calculate totals
   const totalVApps = filteredVApps.length;
   const totalVMs = filteredVApps.reduce(
-    (sum, vApp) => sum + (vApp.numberOfVMs || vApp.vms?.length || 0),
+    (sum, vApp) => sum + (vApp.numberOfVMs ?? vApp.vms?.length ?? 0),
     0
   );
 
@@ -892,7 +892,7 @@ const VMs: React.FC = () => {
                             </div>
                           </Td>
                           <Td>
-                            {vApp.numberOfVMs || vApp.vms?.length || 0} VMs
+                            {vApp.numberOfVMs ?? vApp.vms?.length ?? 0} VMs
                           </Td>
                           <Td>{getVAppStatusBadge(vApp.status)}</Td>
                           <Td>

--- a/src/pages/vms/VMs.tsx
+++ b/src/pages/vms/VMs.tsx
@@ -362,6 +362,31 @@ const VMs: React.FC = () => {
     );
   };
 
+  const getVAppStatusBadge = (status: string) => {
+    const statusConfig = {
+      INSTANTIATING: { color: 'blue' as const, icon: ExclamationTriangleIcon },
+      RESOLVED: { color: 'blue' as const, icon: ExclamationTriangleIcon },
+      DEPLOYED: { color: 'green' as const, icon: PlayIcon },
+      POWERED_ON: { color: 'green' as const, icon: PlayIcon },
+      POWERED_OFF: { color: 'red' as const, icon: PowerOffIcon },
+      MIXED: { color: 'orange' as const, icon: ExclamationTriangleIcon },
+      FAILED: { color: 'red' as const, icon: ExclamationTriangleIcon },
+      UNKNOWN: { color: 'grey' as const, icon: ExclamationTriangleIcon },
+    };
+
+    const config = statusConfig[status as keyof typeof statusConfig] || {
+      color: 'grey' as const,
+      icon: ExclamationTriangleIcon,
+    };
+    const IconComponent = config.icon;
+
+    return (
+      <Label color={config.color} icon={<IconComponent />}>
+        {status}
+      </Label>
+    );
+  };
+
   const formatMemory = (memoryMb: number) => {
     if (memoryMb >= 1024) {
       return `${(memoryMb / 1024).toFixed(1)} GB`;
@@ -833,7 +858,6 @@ const VMs: React.FC = () => {
                       <Th>vApp Name</Th>
                       <Th>VMs</Th>
                       <Th>Status</Th>
-                      <Th>Organization</Th>
                       <Th>Created</Th>
                       <Th>Actions</Th>
                     </Tr>
@@ -868,37 +892,7 @@ const VMs: React.FC = () => {
                             </div>
                           </Td>
                           <Td>{vApp.vms?.length || 0} VMs</Td>
-                          <Td>
-                            {vApp.vms?.length ? (
-                              <div>
-                                {vApp.vms.map((vm, index) => (
-                                  <div
-                                    key={vm.id}
-                                    style={{
-                                      display: 'inline-block',
-                                      marginRight: '4px',
-                                    }}
-                                  >
-                                    {getStatusBadge(vm.status)}
-                                    {index < vApp.vms!.length - 1 && ', '}
-                                  </div>
-                                ))}
-                              </div>
-                            ) : (
-                              <span className="pf-v6-u-color-200">No VMs</span>
-                            )}
-                          </Td>
-                          <Td>
-                            <Link
-                              to={ROUTES.ORGANIZATION_DETAIL.replace(
-                                ':id',
-                                vApp.org?.id || ''
-                              )}
-                              className="pf-v6-c-button pf-v6-m-link pf-v6-m-inline"
-                            >
-                              {vApp.org?.name || 'Unknown'}
-                            </Link>
-                          </Td>
+                          <Td>{getVAppStatusBadge(vApp.status)}</Td>
                           <Td>
                             {vApp.createdDate
                               ? formatDate(vApp.createdDate)

--- a/src/pages/vms/VMs.tsx
+++ b/src/pages/vms/VMs.tsx
@@ -891,11 +891,13 @@ const VMs: React.FC = () => {
                               </Link>
                             </div>
                           </Td>
-                          <Td>{vApp.vms?.length || 0} VMs</Td>
+                          <Td>
+                            {vApp.numberOfVMs || vApp.vms?.length || 0} VMs
+                          </Td>
                           <Td>{getVAppStatusBadge(vApp.status)}</Td>
                           <Td>
-                            {vApp.createdDate
-                              ? formatDate(vApp.createdDate)
+                            {vApp.createdAt || vApp.createdDate
+                              ? formatDate(vApp.createdAt || vApp.createdDate)
                               : 'Unknown'}
                           </Td>
                           <Td>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -578,9 +578,11 @@ export interface VApp {
   href: string;
   type: string;
   createdDate: string;
+  createdAt?: string; // Alternative field name from API
   lastModifiedDate: string;
   vms?: VMCloudAPI[];
   networks?: VAppNetwork[];
+  numberOfVMs?: number; // VM count from API response
   owner?: EntityRef;
   org?: EntityRef;
   vdc?: EntityRef;


### PR DESCRIPTION
## Summary
- Remove Organization column from vApps table as requested in issue #56
- Fix Status column to show vApp status instead of individual VM statuses  
- Add new `getVAppStatusBadge` function for proper vApp status display

## Changes Made
- Removed Organization column from table header and body in `/src/pages/vms/VMs.tsx`
- Added `getVAppStatusBadge` function with proper vApp status handling
- Updated Status column to use `{getVAppStatusBadge(vApp.status)}` instead of individual VM status

## Test Plan
- [x] All tests pass (35/35)
- [x] Linting clean 
- [x] Build successful
- [x] vApps table now shows proper vApp status instead of VM status
- [x] Organization column successfully removed

Fixes #56

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual status badges for vApps, showing common states with color and icon cues.
  * VM counts per vApp now more accurate, using an API-provided total when available.
  * Display of creation date is more robust, showing an alternative field when present and “Unknown” if missing.
  * Simplified vApp table: removed Organization column and nested VM rows to focus on high-level vApp details while retaining existing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->