### PR TITLE
Remove 404 virtualHardwareSection endpoint and cleanup unused code

### DIFF
--- a/docs/enhancements/vm-creation-api-implementation.md
+++ b/docs/enhancements/vm-creation-api-implementation.md
@@ -107,8 +107,7 @@ GET /cloudapi/1.0.0/vapps/{vapp_id}
 GET /cloudapi/1.0.0/vms/{vm_id}
 // Get VM details and status
 
-GET /cloudapi/1.0.0/vms/{vm_id}/virtualHardwareSection
-// Get VM hardware configuration
+// NOTE: virtualHardwareSection endpoint removed - hardware data is embedded in VM object
 ```
 
 ### Implementation Plan
@@ -175,15 +174,7 @@ export class VMService {
     return response.data;
   }
 
-  /**
-   * Get VM hardware configuration
-   */
-  static async getVMHardware(vmId: string): Promise<VMHardwareSection> {
-    const response = await api.get<VMHardwareSection>(
-      `/cloudapi/1.0.0/vms/${encodeURIComponent(vmId)}/virtualHardwareSection`
-    );
-    return response.data;
-  }
+  // NOTE: getVMHardware method removed - hardware data is embedded in VM object
 }
 ```
 
@@ -254,8 +245,7 @@ export interface VM {
   createdDate: string;
   lastModifiedDate: string;
 
-  // Hardware details
-  virtualHardwareSection?: VMHardwareSection;
+  // Hardware details - now embedded in hardware field using VMHardware interface
   guestCustomizationSection?: VMGuestCustomizationSection;
   networkConnectionSection?: VMNetworkConnectionSection;
 
@@ -288,22 +278,8 @@ export type VAppStatus =
   | 'UNKNOWN';
 
 // Hardware Configuration
-export interface VMHardwareSection {
-  items: VMHardwareItem[];
-  links: Link[];
-}
-
-export interface VMHardwareItem {
-  id: number;
-  resourceType: number;
-  resourceSubType?: string;
-  elementName: string;
-  description?: string;
-  quantity: number;
-  units?: string;
-  virtualQuantity?: number;
-  virtualQuantityUnits?: string;
-}
+// NOTE: VMHardwareSection and VMHardwareItem interfaces removed
+// Use VMHardware interface instead: { numCpus, memoryMB, coresPerSocket }
 ```
 
 #### Phase 3: React Hooks Updates ✅ COMPLETED

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -64,7 +64,6 @@ export {
   useVAppStatus,
   useVMDetails,
   useVMDetailsWithAutoRefresh,
-  useVMHardware,
   useCloudAPIVMs,
   useVApps as useCloudAPIVApps,
   usePowerOnVM as useCloudAPIPowerOnVM,

--- a/src/hooks/useCloudAPIVMs.ts
+++ b/src/hooks/useCloudAPIVMs.ts
@@ -277,7 +277,6 @@ export const useDeleteVM = () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.vapps });
       // Remove the specific VM detail cache
       queryClient.removeQueries({ queryKey: QUERY_KEYS.cloudApiVM(vmId) });
-      queryClient.removeQueries({ queryKey: QUERY_KEYS.vmHardware(vmId) });
     },
   });
 };

--- a/src/hooks/useCloudAPIVMs.ts
+++ b/src/hooks/useCloudAPIVMs.ts
@@ -188,19 +188,6 @@ export const useVMDetailsWithAutoRefresh = (
 };
 
 /**
- * Hook to get VM hardware configuration
- */
-export const useVMHardware = (vmId?: string) => {
-  return useQuery({
-    queryKey: QUERY_KEYS.vmHardware(vmId || ''),
-    queryFn: () => VMService.getVMHardware(vmId!),
-    enabled: !!vmId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-  });
-};
-
-/**
  * Hook to get all VMs using CloudAPI
  */
 export const useCloudAPIVMs = () => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -581,53 +581,6 @@ export const handlers = [
     return HttpResponse.json(vm);
   }),
 
-  // Get VM hardware configuration
-  http.get(
-    '/cloudapi/1.0.0/vms/:vmUrn/virtualHardwareSection',
-    ({ params }) => {
-      const { vmUrn } = params;
-
-      // Mock hardware section
-      const hardwareSection = {
-        items: [
-          {
-            id: 1,
-            resourceType: 3,
-            elementName: 'CPU',
-            quantity: 2,
-            virtualQuantity: 2,
-            virtualQuantityUnits: 'hertz * 10^6',
-          },
-          {
-            id: 2,
-            resourceType: 4,
-            elementName: 'Memory',
-            quantity: 4096,
-            virtualQuantity: 4096,
-            virtualQuantityUnits: 'byte * 2^20',
-          },
-          {
-            id: 3,
-            resourceType: 17,
-            elementName: 'Hard Disk 1',
-            quantity: 50,
-            virtualQuantity: 50,
-            virtualQuantityUnits: 'byte * 2^30',
-          },
-        ],
-        links: [
-          {
-            rel: 'edit',
-            href: `https://vcd.example.com/cloudapi/1.0.0/vms/${vmUrn}/virtualHardwareSection`,
-            type: 'application/json',
-          },
-        ],
-      };
-
-      return HttpResponse.json(hardwareSection);
-    }
-  ),
-
   // VM Power Operations
   http.post('/cloudapi/1.0.0/vms/:vmUrn/actions/powerOn', () => {
     return HttpResponse.json(

--- a/src/pages/vapps/VAppDetail.tsx
+++ b/src/pages/vapps/VAppDetail.tsx
@@ -67,12 +67,11 @@ import { VMService } from '../../services/cloudapi/VMService';
 import { VDCPublicService } from '../../services/cloudapi/VDCPublicService';
 import { VDCAdminService } from '../../services/cloudapi/VDCAdminService';
 import { OrganizationService } from '../../services/cloudapi/OrganizationService';
-import type { VMStatus, VMCloudAPI, VMHardwareSection, VDC } from '../../types';
+import type { VMStatus, VMCloudAPI, VDC } from '../../types';
 import { ROUTES, VM_STATUS_LABELS } from '../../utils/constants';
 
 interface VMDetailData {
   vm: VMCloudAPI;
-  hardware?: VMHardwareSection;
   loading: boolean;
   error?: string;
 }
@@ -275,7 +274,6 @@ const VAppDetail: React.FC = () => {
         if (hasHardwareData && hasCreatedDate) {
           newVmDetails.set(vmId, {
             vm: vmCloudAPI,
-            hardware: undefined, // Hardware data is embedded in the VM object
             loading: false,
           });
           continue;
@@ -288,15 +286,11 @@ const VAppDetail: React.FC = () => {
         });
 
         try {
-          // Fetch VM details and hardware in parallel
-          const [vmDetail, vmHardware] = await Promise.all([
-            VMService.getVM(vmId),
-            VMService.getVMHardware(vmId).catch(() => undefined), // Hardware might not be available
-          ]);
+          // Fetch VM details
+          const vmDetail = await VMService.getVM(vmId);
 
           newVmDetails.set(vmId, {
             vm: vmDetail,
-            hardware: vmHardware,
             loading: false,
           });
         } catch (error) {

--- a/src/services/cloudapi/VMService.ts
+++ b/src/services/cloudapi/VMService.ts
@@ -6,7 +6,6 @@ import type {
   InstantiateTemplateRequest,
   VApp,
   VMCloudAPI,
-  VMHardwareSection,
 } from '../../types';
 
 /**
@@ -102,18 +101,6 @@ export class VMService {
       {
         signal: options?.signal,
       }
-    );
-    return response.data;
-  }
-
-  /**
-   * Get VM hardware configuration
-   * Returns detailed hardware specifications including CPU, memory, and virtual devices
-   * @param vmId The VM URN
-   */
-  static async getVMHardware(vmId: string): Promise<VMHardwareSection> {
-    const response = await cloudApi.get<VMHardwareSection>(
-      `/1.0.0/vms/${encodeURIComponent(vmId)}/virtualHardwareSection`
     );
     return response.data;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -655,8 +655,6 @@ export interface VMCloudAPI {
   // Hardware details - ssvirt API format
   hardware?: VMHardware;
 
-  // Legacy vCloud Director hardware details (for backward compatibility)
-  virtualHardwareSection?: VMHardwareSection;
   guestCustomizationSection?: VMGuestCustomizationSection;
   networkConnectionSection?: VMNetworkConnectionSection;
 
@@ -668,11 +666,21 @@ export interface VMCloudAPI {
 }
 
 // Hardware Configuration
+/**
+ * @deprecated This interface is deprecated. The virtualHardwareSection endpoint
+ * does not exist in the ssvirt API. Use the embedded `hardware` field in VMCloudAPI
+ * instead, which uses the VMHardware interface with numCpus, memoryMB, and coresPerSocket.
+ * This will be removed in a future version.
+ */
 export interface VMHardwareSection {
   items: VMHardwareItem[];
   links: Link[];
 }
 
+/**
+ * @deprecated This interface is deprecated and will be removed in a future version.
+ * Use the VMHardware interface instead.
+ */
 export interface VMHardwareItem {
   id: number;
   resourceType: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -665,34 +665,6 @@ export interface VMCloudAPI {
   catalogItem?: EntityRef;
 }
 
-// Hardware Configuration
-/**
- * @deprecated This interface is deprecated. The virtualHardwareSection endpoint
- * does not exist in the ssvirt API. Use the embedded `hardware` field in VMCloudAPI
- * instead, which uses the VMHardware interface with numCpus, memoryMB, and coresPerSocket.
- * This will be removed in a future version.
- */
-export interface VMHardwareSection {
-  items: VMHardwareItem[];
-  links: Link[];
-}
-
-/**
- * @deprecated This interface is deprecated and will be removed in a future version.
- * Use the VMHardware interface instead.
- */
-export interface VMHardwareItem {
-  id: number;
-  resourceType: number;
-  resourceSubType?: string;
-  elementName: string;
-  description?: string;
-  quantity: number;
-  units?: string;
-  virtualQuantity?: number;
-  virtualQuantityUnits?: string;
-}
-
 // Guest Customization
 export interface VMGuestCustomizationSection {
   enabled: boolean;
@@ -945,7 +917,6 @@ export const QUERY_KEYS = {
   vmVdcs: ['cloudapi', 'vms', 'vdcs'] as const,
   cloudApiVMs: ['cloudapi', 'vms'] as const,
   cloudApiVM: (id: string) => ['cloudapi', 'vms', id] as const,
-  vmHardware: (id: string) => ['cloudapi', 'vms', id, 'hardware'] as const,
 
   // CloudAPI vApps
   vapps: ['cloudapi', 'vapps'] as const,

--- a/src/utils/vmTransformers.ts
+++ b/src/utils/vmTransformers.ts
@@ -17,14 +17,8 @@ export const transformVMData = (cloudApiVM: VMCloudAPI): VM => {
     vm_name: cloudApiVM.name,
     namespace: cloudApiVM.org?.name || '',
     status: cloudApiVM.status,
-    cpu_count:
-      cloudApiVM.virtualHardwareSection?.items.find(
-        (item) => item.resourceType === 3
-      )?.virtualQuantity || 1,
-    memory_mb:
-      cloudApiVM.virtualHardwareSection?.items.find(
-        (item) => item.resourceType === 4
-      )?.virtualQuantity || 1024,
+    cpu_count: cloudApiVM.hardware?.numCpus || 1,
+    memory_mb: cloudApiVM.hardware?.memoryMB || 1024,
     created_at: cloudApiVM.createdDate,
     updated_at: cloudApiVM.lastModifiedDate,
     vdc_id: cloudApiVM.vdc?.id || '',


### PR DESCRIPTION
## Summary
Fixes the 404 error when loading vApp detail view by removing calls to the non-existent `/virtualHardwareSection` endpoint and cleaning up related unused code.

## Problem
The vApp detail view was making calls to `/cloudapi/1.0.0/vms/{vmId}/virtualHardwareSection` which returns 404 because this endpoint doesn't exist in the ssvirt API. This was causing console errors when viewing vApp details.

## Solution
- **Removed `VMService.getVMHardware()` method** that was calling the non-existent endpoint
- **Removed `useVMHardware` hook** since it wasn't being used anywhere in the codebase
- **Updated VAppDetail.tsx** to only fetch VM details since hardware data is now embedded in the VM object
- **Cleaned up type definitions** by removing unused `VMHardwareSection` imports and interfaces
- **Removed mock handler** for the virtualHardwareSection endpoint

## Technical Details
The VM hardware information is now properly accessed through the embedded `hardware` field in the VM object (using the `VMHardware` interface), which contains:
- `numCpus` - CPU core count
- `memoryMB` - Memory in megabytes  
- `coresPerSocket` - Cores per socket

## Test Plan
- [x] All existing tests pass (35/35)
- [x] Linting passes without errors
- [x] Code formatting applied with `make format`
- [x] No more 404 errors in browser console when viewing vApp details
- [x] VM hardware data still displays correctly in the UI using embedded data

## Impact
- Eliminates 404 console errors when viewing vApp details
- Removes unused code and improves codebase maintainability
- No breaking changes to existing functionality

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * VM hardware is no longer exposed via a separate endpoint or hook; hardware details are now embedded in VM objects.
  * VApp detail pages no longer load per-VM hardware separately, reducing background requests and improving load responsiveness.
  * Mock data and client mappings updated to the consolidated hardware model.
  * No changes to VM lifecycle actions or core VM management behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->