### PR TITLE
Fix VDC visibility for vApp Users during vApp creation

### DIFF
--- a/docs/enhancements/vm-creation-api-implementation.md
+++ b/docs/enhancements/vm-creation-api-implementation.md
@@ -287,17 +287,10 @@ export type VAppStatus =
 **CloudAPI VM Hooks (`src/hooks/useCloudAPIVMs.ts`) ✅**
 
 ```typescript
-/**
- * Hook to get accessible VDCs for VM creation
- */
-export const useVMVDCs = () => {
-  return useQuery({
-    queryKey: QUERY_KEYS.vmVdcs,
-    queryFn: () => VMService.getVDCs(),
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-  });
-};
+// DEPRECATED: useVMVDCs has been removed in favor of useOrganizationVDCs
+// The VM Creation Wizard now uses useOrganizationVDCs() for proper role-based
+// VDC filtering that works for all user types (System Admin, Org Admin, vApp User).
+// See: useVDC.ts:useOrganizationVDCs()
 
 /**
  * Hook to get catalog items (templates) for VM creation

--- a/src/components/vms/VMCreationWizard.tsx
+++ b/src/components/vms/VMCreationWizard.tsx
@@ -9,10 +9,10 @@ import {
 } from '@patternfly/react-core';
 import {
   useInstantiateTemplate,
-  useVMVDCs,
   useCatalogs,
   useAllCatalogItems,
   useVAppStatus,
+  useOrganizationVDCs,
 } from '../../hooks';
 import type {
   InstantiateTemplateRequest,
@@ -111,7 +111,10 @@ const VMCreationWizard: React.FC<VMCreationWizardProps> = ({
 
   // Hooks
   const instantiateTemplateMutation = useInstantiateTemplate();
-  const { data: vdcsResponse } = useVMVDCs();
+
+  // Use organization VDCs for all users - this works for both admin and regular users
+  // and properly applies organization-scoped filtering
+  const { data: vdcsResponse } = useOrganizationVDCs();
   const vdcs = vdcsResponse?.values || [];
   const { data: catalogsResponse } = useCatalogs();
   const catalogs = catalogsResponse?.values || [];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -57,7 +57,6 @@ export {
 
 // Export CloudAPI VM hooks
 export {
-  useVMVDCs,
   useCatalogItems as useCloudAPICatalogItems,
   useAllCatalogItems,
   useInstantiateTemplate,

--- a/src/hooks/useCloudAPIVMs.ts
+++ b/src/hooks/useCloudAPIVMs.ts
@@ -9,18 +9,6 @@ import type {
 } from '../types';
 
 /**
- * Hook to get accessible VDCs for VM creation
- */
-export const useVMVDCs = () => {
-  return useQuery({
-    queryKey: QUERY_KEYS.vmVdcs,
-    queryFn: () => VMService.getVDCs(),
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-  });
-};
-
-/**
  * Hook to get catalog items (templates) for VM creation
  */
 export const useCatalogItems = (catalogId?: string) => {

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -701,7 +701,7 @@ export const generateMockUserPermissions = (): UserPermissions => ({
   canManageOrganizations: false,
   canViewVDCs: true,
   canManageVDCs: false,
-  canCreateVApps: false, // Regular users cannot create vApps
+  canCreateVApps: false, // Regular users cannot create vApps (this is for non-vApp users)
   accessibleOrganizations: [
     {
       id: 'urn:vcloud:org:12345678-1234-1234-1234-123456789abc',
@@ -743,6 +743,22 @@ export const generateMockOrgAdminPermissions = (): UserPermissions => ({
   canViewVDCs: true,
   canManageVDCs: false, // Cannot manage VDCs globally
   canCreateVApps: true, // Organization Admins can create vApps
+  accessibleOrganizations: [
+    {
+      id: 'urn:vcloud:org:12345678-1234-1234-1234-123456789abc',
+      name: 'Engineering',
+    },
+  ],
+});
+
+export const generateMockVAppUserPermissions = (): UserPermissions => ({
+  canCreateOrganizations: false,
+  canManageUsers: false,
+  canManageSystem: false,
+  canManageOrganizations: false,
+  canViewVDCs: true,
+  canManageVDCs: false,
+  canCreateVApps: true, // vApp Users can create vApps
   accessibleOrganizations: [
     {
       id: 'urn:vcloud:org:12345678-1234-1234-1234-123456789abc',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -937,7 +937,6 @@ export const QUERY_KEYS = {
   vmsByVdc: (vdcId: string) => ['vms', 'vdc', vdcId] as const,
 
   // CloudAPI VMs
-  vmVdcs: ['cloudapi', 'vms', 'vdcs'] as const,
   cloudApiVMs: ['cloudapi', 'vms'] as const,
   cloudApiVM: (id: string) => ['cloudapi', 'vms', id] as const,
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -132,7 +132,7 @@ export class PermissionChecker {
       canManageOrganizations: isSystemAdmin,
       canViewVDCs: true, // All authenticated users can view VDCs
       canManageVDCs: isSystemAdmin,
-      canCreateVApps: isSystemAdmin || isOrgAdmin, // System Admins and Org Admins can create vApps
+      canCreateVApps: isSystemAdmin || isOrgAdmin || this.isVAppUser(user), // System Admins, Org Admins, and vApp Users can create vApps
       // System admins get empty array to indicate access to all orgs
       accessibleOrganizations: isSystemAdmin
         ? []


### PR DESCRIPTION
## Summary
Fixes vApp Users' inability to see VDCs during vApp creation, resolving the "No VDCs available" error.

## Root Cause
The issue had two components:
1. **Permission Logic**: vApp Users were incorrectly excluded from `canCreateVApps` permission  
2. **VDC Fetching**: VM Creation Wizard used direct VDC API calls without proper organization-scoped filtering

## Changes Made
- **Enable vApp Users to create vApps** by updating permission logic in `src/utils/permissions.ts`
- **Fix VDC visibility** by replacing `useVMVDCs` with `useOrganizationVDCs` in VM Creation Wizard
- **Add mock data** for vApp User permissions to support testing scenarios  
- **Align with main VMs page** logic that already handles role-based VDC filtering correctly

## Technical Details
### Permission Fix (`src/utils/permissions.ts`)
```typescript
// Before
canCreateVApps: isSystemAdmin || isOrgAdmin

// After  
canCreateVApps: isSystemAdmin || isOrgAdmin || this.isVAppUser(user)
```

### VDC Fetching Fix (`src/components/vms/VMCreationWizard.tsx`)
```typescript
// Before: Direct API call without role-based filtering
const { data: vdcsResponse } = useVMVDCs();

// After: Organization-scoped VDC fetching  
const { data: vdcsResponse } = useOrganizationVDCs();
```

## Test Plan
- [x] TypeScript compilation passes
- [x] Code formatting applied
- [x] Production build succeeds
- [x] Changes align with existing VMs page logic
- [ ] Manual testing with vApp User role
- [ ] Verify VDCs are visible in vApp creation wizard
- [ ] Confirm vApp creation workflow completes successfully

## Fixes
Closes #70

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - VM Creation Wizard now lists organization-level VDCs so users can select from all VDCs in their organization.
  - VApp Users are now permitted to create vApps in addition to System and Org Admins.
- Documentation
  - Updated guidance to deprecate the legacy VM VDC API and point to the organization-scoped VDC approach.
- Tests/Mocks
  - Added a mock generator for VApp user permissions to support testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->