### PR TITLE
Fix vApp User VDC access in Create vApp modal

### DIFF
--- a/src/contexts/RoleContext.tsx
+++ b/src/contexts/RoleContext.tsx
@@ -73,6 +73,7 @@ export const RoleProvider: React.FC<RoleProviderProps> = ({ children }) => {
         canManageVMs: false,
         canViewVDCs: false,
         canViewReports: false,
+        canCreateVApps: false,
         primaryOrganization: '',
         operatingOrganization: undefined,
       };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -367,6 +367,11 @@ export class AuthService {
       (role) => role === ROLE_NAMES.ORG_ADMIN
     );
 
+    // Check if user has vApp user role
+    const isVAppUser = sessionData.roles.some(
+      (role) => role === ROLE_NAMES.VAPP_USER
+    );
+
     // Extract user's organizations
     // [] means all organizations / global scope
     const accessibleOrganizations = isSystemAdmin
@@ -387,7 +392,7 @@ export class AuthService {
       canManageOrganizations: isSystemAdmin,
       canViewVDCs: true, // All authenticated users can view VDCs
       canManageVDCs: isSystemAdmin,
-      canCreateVApps: isSystemAdmin || isOrgAdmin, // Organization Admins can create vApps
+      canCreateVApps: isSystemAdmin || isOrgAdmin || isVAppUser, // vApp Users can create vApps
       accessibleOrganizations,
     };
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,7 @@ export interface RoleCapabilities {
   canManageVMs: boolean;
   canViewVDCs: boolean;
   canViewReports: boolean;
+  canCreateVApps: boolean;
   primaryOrganization: string; // Primary organization ID from login response
   operatingOrganization?: string; // Operating organization ID if different
 }

--- a/src/utils/roleDetection.ts
+++ b/src/utils/roleDetection.ts
@@ -59,6 +59,7 @@ export function determineUserCapabilities(
     canManageVMs: isSystemAdmin || isOrgAdmin || isVappUser,
     canViewVDCs: isSystemAdmin || isOrgAdmin || isVappUser,
     canViewReports: isSystemAdmin || isOrgAdmin,
+    canCreateVApps: isSystemAdmin || isOrgAdmin || isVappUser,
     primaryOrganization: sessionResponse.org.id,
     operatingOrganization: sessionResponse.operatingOrg?.id,
   };


### PR DESCRIPTION
## Summary
Fixes issue where vApp Users see "No VDCs available" in the Create vApp modal, even though the API returns VDCs successfully and the same VDCs are visible to Organization Admins and System Admins.

## Root Cause
The `AuthService.getCurrentUserPermissions()` method was not granting the `canCreateVApps` permission to vApp Users, causing the `useAccessibleVDCs` hook to return an empty array and display "No VDCs available".

## Changes Made
- **Added `canCreateVApps` property to `RoleCapabilities` interface** for type consistency
- **Updated `roleDetection.ts`** to grant `canCreateVApps` to vApp Users via `determineUserCapabilities()`  
- **Updated `RoleContext.tsx`** to include `canCreateVApps: false` in fallback capabilities object
- **Fixed `AuthService.getCurrentUserPermissions()`** to include vApp Users in the `canCreateVApps` check

## Impact
- ✅ vApp Users can now see and select VDCs in Create vApp modal
- ✅ vApp Users can successfully create vApps from catalog templates
- ✅ Maintains existing behavior for System Admins and Organization Admins
- ✅ Aligns frontend permissions with intended role capabilities

## Test Plan
1. Log in as a vApp User
2. Navigate to a catalog
3. Click "Create vApp" button on any catalog item
4. Verify VDCs appear in "Target VDC" dropdown instead of "No VDCs available"
5. Verify vApp creation works successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new capability: canCreateVApps.
  * Users with the VAPP_USER role (as well as Org/System Admins) can now create vApps.
  * App-wide permission checks and UI capability indicators now reflect this new permission.
  * When not signed in, the capability defaults to disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->